### PR TITLE
feat(infra): initialize pnpm/turborepo monorepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm build

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@agentmesh/server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "description": "Fastify REST API server",
+  "dependencies": {
+    "@agentmesh/core": "workspace:*",
+    "@agentmesh/toolkit": "workspace:*",
+    "@agentmesh/policy": "workspace:*",
+    "@agentmesh/trace": "workspace:*",
+    "@agentmesh/ui-contracts": "workspace:*"
+  },
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  }
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,0 +1,2 @@
+// TODO: implement Fastify server
+console.log("server placeholder");

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@agentmesh/web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Next.js dashboard",
+  "scripts": {
+    "dev": "echo 'web: not yet implemented'",
+    "build": "echo 'web: not yet implemented'",
+    "start": "echo 'web: not yet implemented'"
+  }
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,16 @@
+export const metadata = {
+  title: "AgentMesh",
+  description: "AgentMesh Dashboard",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>AgentMesh</div>;
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/research-agent/package.json
+++ b/examples/research-agent/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@agentmesh/example-research-agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Example research agent",
+  "dependencies": {
+    "@agentmesh/core": "workspace:*",
+    "@agentmesh/toolkit": "workspace:*"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  }
+}

--- a/examples/research-agent/src/index.ts
+++ b/examples/research-agent/src/index.ts
@@ -1,0 +1,2 @@
+// TODO: implement research agent example
+export {};

--- a/examples/research-agent/tsconfig.json
+++ b/examples/research-agent/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "agentmesh-ts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "lint": "turbo run lint",
+    "typecheck": "turbo run typecheck",
+    "test": "turbo run test",
+    "clean": "turbo run clean"
+  },
+  "devDependencies": {
+    "turbo": "^2.5.0",
+    "typescript": "^5.8.3"
+  },
+  "packageManager": "pnpm@10.15.1"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@agentmesh/core",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "description": "Core domain types and runtime",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,2 @@
+// TODO: implement
+export {};

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/policy/package.json
+++ b/packages/policy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@agentmesh/policy",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "description": "Policy engine for agent governance",
+  "dependencies": {
+    "@agentmesh/core": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  }
+}

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -1,0 +1,2 @@
+// TODO: implement
+export {};

--- a/packages/policy/tsconfig.json
+++ b/packages/policy/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@agentmesh/provider-anthropic",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "description": "Anthropic provider adapter",
+  "dependencies": {
+    "@agentmesh/core": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  }
+}

--- a/packages/provider-anthropic/src/index.ts
+++ b/packages/provider-anthropic/src/index.ts
@@ -1,0 +1,2 @@
+// TODO: implement
+export {};

--- a/packages/provider-anthropic/tsconfig.json
+++ b/packages/provider-anthropic/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@agentmesh/provider-openai",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "description": "OpenAI provider adapter",
+  "dependencies": {
+    "@agentmesh/core": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  }
+}

--- a/packages/provider-openai/src/index.ts
+++ b/packages/provider-openai/src/index.ts
@@ -1,0 +1,2 @@
+// TODO: implement
+export {};

--- a/packages/provider-openai/tsconfig.json
+++ b/packages/provider-openai/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@agentmesh/toolkit",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "description": "Typed tool contracts and registry",
+  "dependencies": {
+    "@agentmesh/core": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  }
+}

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -1,0 +1,2 @@
+// TODO: implement
+export {};

--- a/packages/toolkit/tsconfig.json
+++ b/packages/toolkit/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/trace/package.json
+++ b/packages/trace/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@agentmesh/trace",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "description": "Execution trace storage and metrics",
+  "dependencies": {
+    "@agentmesh/core": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  }
+}

--- a/packages/trace/src/index.ts
+++ b/packages/trace/src/index.ts
@@ -1,0 +1,2 @@
+// TODO: implement
+export {};

--- a/packages/trace/tsconfig.json
+++ b/packages/trace/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ui-contracts/package.json
+++ b/packages/ui-contracts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@agentmesh/ui-contracts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "description": "Shared types for API and UI",
+  "dependencies": {
+    "@agentmesh/core": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  }
+}

--- a/packages/ui-contracts/src/index.ts
+++ b/packages/ui-contracts/src/index.ts
@@ -1,0 +1,2 @@
+// TODO: implement
+export {};

--- a/packages/ui-contracts/tsconfig.json
+++ b/packages/ui-contracts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,155 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      turbo:
+        specifier: ^2.5.0
+        version: 2.8.16
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
+  apps/server:
+    dependencies:
+      '@agentmesh/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@agentmesh/policy':
+        specifier: workspace:*
+        version: link:../../packages/policy
+      '@agentmesh/toolkit':
+        specifier: workspace:*
+        version: link:../../packages/toolkit
+      '@agentmesh/trace':
+        specifier: workspace:*
+        version: link:../../packages/trace
+      '@agentmesh/ui-contracts':
+        specifier: workspace:*
+        version: link:../../packages/ui-contracts
+
+  apps/web: {}
+
+  examples/research-agent:
+    dependencies:
+      '@agentmesh/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@agentmesh/toolkit':
+        specifier: workspace:*
+        version: link:../../packages/toolkit
+
+  packages/core: {}
+
+  packages/policy:
+    dependencies:
+      '@agentmesh/core':
+        specifier: workspace:*
+        version: link:../core
+
+  packages/provider-anthropic:
+    dependencies:
+      '@agentmesh/core':
+        specifier: workspace:*
+        version: link:../core
+
+  packages/provider-openai:
+    dependencies:
+      '@agentmesh/core':
+        specifier: workspace:*
+        version: link:../core
+
+  packages/toolkit:
+    dependencies:
+      '@agentmesh/core':
+        specifier: workspace:*
+        version: link:../core
+
+  packages/trace:
+    dependencies:
+      '@agentmesh/core':
+        specifier: workspace:*
+        version: link:../core
+
+  packages/ui-contracts:
+    dependencies:
+      '@agentmesh/core':
+        specifier: workspace:*
+        version: link:../core
+
+packages:
+
+  turbo-darwin-64@2.8.16:
+    resolution: {integrity: sha512-KWa4hUMWrpADC6Q/wIHRkBLw6X6MV9nx6X7hSXbTrrMz0KdaKhmfudUZ3sS76bJFmgArBU25cSc0AUyyrswYxg==}
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@2.8.16:
+    resolution: {integrity: sha512-NBgaqBDLQSZlJR4D5XCkQq6noaO0RvIgwm5eYFJYL3bH5dNu8o0UBpq7C5DYnQI8+ybyoHFjT5/icN4LeUYLow==}
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@2.8.16:
+    resolution: {integrity: sha512-VYPdcCRevI9kR/hr1H1xwXy7QQt/jNKiim1e1mjANBXD2E9VZWMkIL74J1Huad5MbU3/jw7voHOqDPLJPC2p6w==}
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@2.8.16:
+    resolution: {integrity: sha512-beq8tgUVI3uwkQkXJMiOr/hfxQRw54M3elpBwqgYFfemiK5LhCjjcwO0DkE8GZZfElBIlk+saMAQOZy3885wNQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@2.8.16:
+    resolution: {integrity: sha512-Ig7b46iUgiOIkea/D3Z7H+zNzvzSnIJcLYFpZLA0RxbUTrbLhv9qIPwv3pT9p/abmu0LXVKHxaOo+p26SuDhzw==}
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@2.8.16:
+    resolution: {integrity: sha512-fOWjbEA2PiE2HEnFQrwNZKYEdjewyPc2no9GmrXklZnTCuMsxeCN39aVlKpKpim03Zq/ykIuvApGwq8ZbfS2Yw==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@2.8.16:
+    resolution: {integrity: sha512-u6e9e3cTTpE2adQ1DYm3A3r8y3LAONEx1jYvJx6eIgSY4bMLxIxs0riWzI0Z/IK903ikiUzRPZ2c1Ph5lVLkhA==}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  turbo-darwin-64@2.8.16:
+    optional: true
+
+  turbo-darwin-arm64@2.8.16:
+    optional: true
+
+  turbo-linux-64@2.8.16:
+    optional: true
+
+  turbo-linux-arm64@2.8.16:
+    optional: true
+
+  turbo-windows-64@2.8.16:
+    optional: true
+
+  turbo-windows-arm64@2.8.16:
+    optional: true
+
+  turbo@2.8.16:
+    optionalDependencies:
+      turbo-darwin-64: 2.8.16
+      turbo-darwin-arm64: 2.8.16
+      turbo-linux-64: 2.8.16
+      turbo-linux-arm64: 2.8.16
+      turbo-windows-64: 2.8.16
+      turbo-windows-arm64: 2.8.16
+
+  typescript@5.9.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - "packages/*"
+  - "apps/*"
+  - "examples/*"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "isolatedModules": true
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "lint": {
+      "dependsOn": ["^build"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"]
+    },
+    "test": {
+      "dependsOn": ["^build"]
+    },
+    "clean": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Scaffold pnpm workspace with Turborepo build pipeline
- 7 packages (core, toolkit, policy, trace, provider-openai, provider-anthropic, ui-contracts)
- 2 apps (server, web placeholder)
- 1 example (research-agent)
- GitHub Actions CI workflow
- Shared tsconfig.base.json

All packages build and typecheck successfully.

Closes #1