### PR TITLE
feat(core): define core domain types with Zod schemas

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,5 +10,8 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,14 @@
-// TODO: implement
-export {};
+export {
+  Run,
+  RunStatus,
+  Step,
+  StepKind,
+  StepStatus,
+  Usage,
+  ToolCall,
+  ToolCallStatus,
+  ExecutionEvent,
+  EventType,
+  PolicyDecision,
+  RuleResult,
+} from "./schema/index.js";

--- a/packages/core/src/schema/event.ts
+++ b/packages/core/src/schema/event.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const EventType = z.enum([
+  "run.created",
+  "run.started",
+  "step.started",
+  "llm.called",
+  "llm.responded",
+  "tool.requested",
+  "tool.completed",
+  "policy.checked",
+  "step.failed",
+  "run.completed",
+]);
+export type EventType = z.infer<typeof EventType>;
+
+export const ExecutionEvent = z.object({
+  id: z.string(),
+  runId: z.string(),
+  stepId: z.string().nullable().default(null),
+  eventType: EventType,
+  payload: z.record(z.string(), z.unknown()).default({}),
+  createdAt: z.string().datetime(),
+});
+export type ExecutionEvent = z.infer<typeof ExecutionEvent>;

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -1,0 +1,5 @@
+export { Run, RunStatus } from "./run.js";
+export { Step, StepKind, StepStatus, Usage } from "./step.js";
+export { ToolCall, ToolCallStatus } from "./tool-call.js";
+export { ExecutionEvent, EventType } from "./event.js";
+export { PolicyDecision, RuleResult } from "./policy.js";

--- a/packages/core/src/schema/policy.ts
+++ b/packages/core/src/schema/policy.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const RuleResult = z.object({
+  ruleName: z.string(),
+  allowed: z.boolean(),
+  reason: z.string().optional(),
+});
+export type RuleResult = z.infer<typeof RuleResult>;
+
+export const PolicyDecision = z.object({
+  allowed: z.boolean(),
+  ruleResults: z.array(RuleResult),
+  requiresApproval: z.boolean(),
+  reason: z.string().optional(),
+});
+export type PolicyDecision = z.infer<typeof PolicyDecision>;

--- a/packages/core/src/schema/run.ts
+++ b/packages/core/src/schema/run.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const RunStatus = z.enum([
+  "queued",
+  "running",
+  "waiting_approval",
+  "succeeded",
+  "failed",
+  "cancelled",
+]);
+export type RunStatus = z.infer<typeof RunStatus>;
+
+export const Run = z.object({
+  id: z.string(),
+  status: RunStatus,
+  agentName: z.string(),
+  goal: z.string(),
+  provider: z.string(),
+  model: z.string(),
+  startedAt: z.string().datetime().nullable(),
+  finishedAt: z.string().datetime().nullable(),
+  totalTokensInput: z.number().int().nonnegative(),
+  totalTokensOutput: z.number().int().nonnegative(),
+  estimatedCostUsd: z.number().nonnegative(),
+  metadata: z.record(z.string(), z.unknown()).default({}),
+});
+export type Run = z.infer<typeof Run>;

--- a/packages/core/src/schema/step.ts
+++ b/packages/core/src/schema/step.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+export const StepKind = z.enum([
+  "plan",
+  "llm_generation",
+  "tool_execution",
+  "policy_check",
+  "finalize",
+]);
+export type StepKind = z.infer<typeof StepKind>;
+
+export const StepStatus = z.enum([
+  "pending",
+  "running",
+  "succeeded",
+  "failed",
+  "skipped",
+]);
+export type StepStatus = z.infer<typeof StepStatus>;
+
+export const Usage = z.object({
+  tokensInput: z.number().int().nonnegative(),
+  tokensOutput: z.number().int().nonnegative(),
+  durationMs: z.number().int().nonnegative(),
+});
+export type Usage = z.infer<typeof Usage>;
+
+export const Step = z.object({
+  id: z.string(),
+  runId: z.string(),
+  index: z.number().int().nonnegative(),
+  kind: StepKind,
+  status: StepStatus,
+  input: z.unknown().optional(),
+  output: z.unknown().optional(),
+  error: z.string().nullable().default(null),
+  usage: Usage.nullable().default(null),
+});
+export type Step = z.infer<typeof Step>;

--- a/packages/core/src/schema/tool-call.ts
+++ b/packages/core/src/schema/tool-call.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const ToolCallStatus = z.enum(["pending", "running", "succeeded", "failed"]);
+export type ToolCallStatus = z.infer<typeof ToolCallStatus>;
+
+export const ToolCall = z.object({
+  id: z.string(),
+  runId: z.string(),
+  stepId: z.string(),
+  toolName: z.string(),
+  input: z.record(z.string(), z.unknown()),
+  output: z.unknown().optional(),
+  status: ToolCallStatus,
+  durationMs: z.number().int().nonnegative().nullable().default(null),
+});
+export type ToolCall = z.infer<typeof ToolCall>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/toolkit
 
-  packages/core: {}
+  packages/core:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   packages/policy:
     dependencies:
@@ -123,6 +127,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   turbo-darwin-64@2.8.16:
@@ -153,3 +160,5 @@ snapshots:
       turbo-windows-arm64: 2.8.16
 
   typescript@5.9.3: {}
+
+  zod@4.3.6: {}


### PR DESCRIPTION
## Summary

- Zod v4 スキーマで Run, Step, ToolCall, ExecutionEvent, PolicyDecision を定義
- runtime validation と TypeScript 型を同一ソースから生成
- 全型が JSON serializable

## 変更内容

| Schema | Fields |
|--------|--------|
| `Run` | id, status(6種), agentName, goal, provider, model, timestamps, tokens, cost, metadata |
| `Step` | id, runId, index, kind(5種), status(5種), input/output, error, usage |
| `ToolCall` | id, runId, stepId, toolName, input/output, status(4種), durationMs |
| `ExecutionEvent` | id, runId, stepId, eventType(10種), payload, createdAt |
| `PolicyDecision` | allowed, ruleResults[], requiresApproval, reason |

Closes #2