### PR TITLE
feat(toolkit): add defineTool API with type-safe tool contracts

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "description": "Typed tool contracts and registry",
   "dependencies": {
-    "@agentmesh/core": "workspace:*"
+    "@agentmesh/core": "workspace:*",
+    "zod": "^4.3.6"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/toolkit/src/define-tool.ts
+++ b/packages/toolkit/src/define-tool.ts
@@ -1,0 +1,80 @@
+import { z, type ZodType, toJSONSchema } from "zod";
+
+export const SideEffectLevel = z.enum([
+  "read_only",
+  "external_read",
+  "external_write",
+  "system_mutation",
+]);
+export type SideEffectLevel = z.infer<typeof SideEffectLevel>;
+
+export interface RetryPolicy {
+  maxAttempts: number;
+  backoffMs: number;
+}
+
+export interface ToolDefinition<
+  TInput extends ZodType = ZodType,
+  TOutput extends ZodType = ZodType,
+> {
+  name: string;
+  description: string;
+  inputSchema: TInput;
+  outputSchema: TOutput;
+  permissionScope: string;
+  sideEffectLevel: SideEffectLevel;
+  timeoutMs: number;
+  retryPolicy?: RetryPolicy;
+  execute: (input: z.infer<TInput>) => Promise<z.infer<TOutput>>;
+}
+
+export interface ToolContract {
+  name: string;
+  description: string;
+  inputJsonSchema: Record<string, unknown>;
+  outputJsonSchema: Record<string, unknown>;
+  permissionScope: string;
+  sideEffectLevel: SideEffectLevel;
+  timeoutMs: number;
+  retryPolicy?: RetryPolicy;
+}
+
+export interface Tool<
+  TInput extends ZodType = ZodType,
+  TOutput extends ZodType = ZodType,
+> extends ToolContract {
+  inputSchema: TInput;
+  outputSchema: TOutput;
+  execute: (input: z.infer<TInput>) => Promise<z.infer<TOutput>>;
+}
+
+export function defineTool<TInput extends ZodType, TOutput extends ZodType>(
+  def: ToolDefinition<TInput, TOutput>,
+): Tool<TInput, TOutput> {
+  return {
+    name: def.name,
+    description: def.description,
+    inputSchema: def.inputSchema,
+    outputSchema: def.outputSchema,
+    inputJsonSchema: toJSONSchema(def.inputSchema) as Record<string, unknown>,
+    outputJsonSchema: toJSONSchema(def.outputSchema) as Record<string, unknown>,
+    permissionScope: def.permissionScope,
+    sideEffectLevel: def.sideEffectLevel,
+    timeoutMs: def.timeoutMs,
+    retryPolicy: def.retryPolicy,
+    execute: def.execute,
+  };
+}
+
+export function toToolContract(tool: Tool): ToolContract {
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputJsonSchema: tool.inputJsonSchema,
+    outputJsonSchema: tool.outputJsonSchema,
+    permissionScope: tool.permissionScope,
+    sideEffectLevel: tool.sideEffectLevel,
+    timeoutMs: tool.timeoutMs,
+    retryPolicy: tool.retryPolicy,
+  };
+}

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -1,2 +1,19 @@
-// TODO: implement
-export {};
+export {
+  defineTool,
+  toToolContract,
+  SideEffectLevel,
+} from "./define-tool.js";
+export type {
+  Tool,
+  ToolContract,
+  ToolDefinition,
+  RetryPolicy,
+} from "./define-tool.js";
+
+export {
+  webSearchTool,
+  readFileTool,
+  writeFileTool,
+  httpFetchTool,
+  runShellTool,
+} from "./tools/index.js";

--- a/packages/toolkit/src/tools/http-fetch.ts
+++ b/packages/toolkit/src/tools/http-fetch.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { defineTool } from "../define-tool.js";
+
+export const httpFetchTool = defineTool({
+  name: "http_fetch",
+  description: "Fetch a public HTTP resource",
+  inputSchema: z.object({
+    url: z.string().url().describe("URL to fetch"),
+    method: z.enum(["GET", "HEAD"]).default("GET").describe("HTTP method"),
+  }),
+  outputSchema: z.object({
+    status: z.number().int(),
+    body: z.string(),
+    headers: z.record(z.string(), z.string()),
+  }),
+  permissionScope: "network:read",
+  sideEffectLevel: "external_read",
+  timeoutMs: 10_000,
+  retryPolicy: { maxAttempts: 2, backoffMs: 500 },
+  async execute(_input) {
+    throw new Error("http_fetch: not implemented — provide a concrete adapter");
+  },
+});

--- a/packages/toolkit/src/tools/index.ts
+++ b/packages/toolkit/src/tools/index.ts
@@ -1,0 +1,5 @@
+export { webSearchTool } from "./web-search.js";
+export { readFileTool } from "./read-file.js";
+export { writeFileTool } from "./write-file.js";
+export { httpFetchTool } from "./http-fetch.js";
+export { runShellTool } from "./run-shell.js";

--- a/packages/toolkit/src/tools/read-file.ts
+++ b/packages/toolkit/src/tools/read-file.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { defineTool } from "../define-tool.js";
+
+export const readFileTool = defineTool({
+  name: "read_file",
+  description: "Read the contents of a file",
+  inputSchema: z.object({
+    path: z.string().describe("Absolute or relative file path"),
+    encoding: z.string().default("utf-8").describe("File encoding"),
+  }),
+  outputSchema: z.object({
+    content: z.string(),
+    size: z.number().int().nonnegative(),
+  }),
+  permissionScope: "file:read",
+  sideEffectLevel: "read_only",
+  timeoutMs: 5_000,
+  async execute(_input) {
+    throw new Error("read_file: not implemented — provide a concrete adapter");
+  },
+});

--- a/packages/toolkit/src/tools/run-shell.ts
+++ b/packages/toolkit/src/tools/run-shell.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { defineTool } from "../define-tool.js";
+
+export const runShellTool = defineTool({
+  name: "run_shell",
+  description: "Execute a shell command",
+  inputSchema: z.object({
+    command: z.string().describe("Shell command to execute"),
+    cwd: z.string().optional().describe("Working directory"),
+    timeoutMs: z.number().int().positive().default(30_000).describe("Command timeout"),
+  }),
+  outputSchema: z.object({
+    exitCode: z.number().int(),
+    stdout: z.string(),
+    stderr: z.string(),
+  }),
+  permissionScope: "shell:exec",
+  sideEffectLevel: "system_mutation",
+  timeoutMs: 60_000,
+  async execute(_input) {
+    throw new Error("run_shell: not implemented — provide a concrete adapter");
+  },
+});

--- a/packages/toolkit/src/tools/web-search.ts
+++ b/packages/toolkit/src/tools/web-search.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import { defineTool } from "../define-tool.js";
+
+export const webSearchTool = defineTool({
+  name: "web_search",
+  description: "Search the web for information",
+  inputSchema: z.object({
+    query: z.string().describe("Search query"),
+    maxResults: z.number().int().positive().default(5).describe("Max results to return"),
+  }),
+  outputSchema: z.object({
+    results: z.array(
+      z.object({
+        title: z.string(),
+        url: z.string(),
+        snippet: z.string(),
+      }),
+    ),
+  }),
+  permissionScope: "network:read",
+  sideEffectLevel: "external_read",
+  timeoutMs: 15_000,
+  retryPolicy: { maxAttempts: 2, backoffMs: 1000 },
+  async execute(_input) {
+    throw new Error("web_search: not implemented — provide a concrete adapter");
+  },
+});

--- a/packages/toolkit/src/tools/write-file.ts
+++ b/packages/toolkit/src/tools/write-file.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { defineTool } from "../define-tool.js";
+
+export const writeFileTool = defineTool({
+  name: "write_file",
+  description: "Write content to a file",
+  inputSchema: z.object({
+    path: z.string().describe("Absolute or relative file path"),
+    content: z.string().describe("Content to write"),
+    encoding: z.string().default("utf-8").describe("File encoding"),
+  }),
+  outputSchema: z.object({
+    bytesWritten: z.number().int().nonnegative(),
+  }),
+  permissionScope: "file:write",
+  sideEffectLevel: "external_write",
+  timeoutMs: 5_000,
+  async execute(_input) {
+    throw new Error("write_file: not implemented — provide a concrete adapter");
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@agentmesh/core':
         specifier: workspace:*
         version: link:../core
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   packages/trace:
     dependencies:


### PR DESCRIPTION
## Summary

- `defineTool()` で Zod スキーマベースの型安全ツール定義
- Zod v4 `toJSONSchema` で自動 JSON Schema 変換（LLM に渡す用）
- `SideEffectLevel` enum で副作用レベルを宣言的に管理
- `toToolContract()` で実行関数を除いた LLM 向けメタデータ抽出
- 5つのサンプルツール: web_search, read_file, write_file, http_fetch, run_shell

## Test plan

- [x] typecheck passing
- [x] build passing
- [ ] ツールレジストリ（#8）で結合テスト予定

Closes #7