### PR TITLE
feat(toolkit): implement tool registry and executor

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -13,6 +13,10 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/toolkit/src/__tests__/executor.test.ts
+++ b/packages/toolkit/src/__tests__/executor.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { defineTool } from "../define-tool.js";
+import { ToolRegistry } from "../registry.js";
+import { ToolExecutor, ToolTimeoutError } from "../executor.js";
+
+function makeEchoTool(opts: { timeoutMs?: number; delay?: number; failCount?: number } = {}) {
+  let calls = 0;
+  return defineTool({
+    name: "echo",
+    description: "Echo input",
+    inputSchema: z.object({ msg: z.string() }),
+    outputSchema: z.object({ echo: z.string() }),
+    permissionScope: "test:read",
+    sideEffectLevel: "read_only",
+    timeoutMs: opts.timeoutMs ?? 5000,
+    retryPolicy: opts.failCount ? { maxAttempts: 3, backoffMs: 10 } : undefined,
+    async execute(input) {
+      calls++;
+      if (opts.delay) await new Promise((r) => setTimeout(r, opts.delay));
+      if (opts.failCount && calls <= opts.failCount) throw new Error("transient");
+      return { echo: input.msg };
+    },
+  });
+}
+
+describe("ToolExecutor", () => {
+  it("executes a tool and returns result", async () => {
+    const registry = new ToolRegistry();
+    registry.register(makeEchoTool());
+    const executor = new ToolExecutor(registry);
+
+    const result = await executor.execute("echo", { msg: "hello" });
+    expect(result.output).toEqual({ echo: "hello" });
+    expect(result.attempts).toBe(1);
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("retries on transient failure", async () => {
+    const registry = new ToolRegistry();
+    registry.register(makeEchoTool({ failCount: 2 }));
+    const executor = new ToolExecutor(registry);
+
+    const result = await executor.execute("echo", { msg: "hi" });
+    expect(result.output).toEqual({ echo: "hi" });
+    expect(result.attempts).toBe(3);
+  });
+
+  it("throws after all retries exhausted", async () => {
+    const registry = new ToolRegistry();
+    registry.register(makeEchoTool({ failCount: 10 }));
+    const executor = new ToolExecutor(registry);
+
+    await expect(executor.execute("echo", { msg: "fail" })).rejects.toThrow("transient");
+  });
+
+  it("throws ToolTimeoutError on timeout", async () => {
+    const registry = new ToolRegistry();
+    registry.register(makeEchoTool({ timeoutMs: 50, delay: 200 }));
+    const executor = new ToolExecutor(registry);
+
+    await expect(executor.execute("echo", { msg: "slow" })).rejects.toThrow(ToolTimeoutError);
+  });
+});

--- a/packages/toolkit/src/__tests__/registry.test.ts
+++ b/packages/toolkit/src/__tests__/registry.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { defineTool } from "../define-tool.js";
+import { ToolRegistry, DuplicateToolError, ToolNotFoundError } from "../registry.js";
+
+function makeTool(name: string) {
+  return defineTool({
+    name,
+    description: `Test tool: ${name}`,
+    inputSchema: z.object({ x: z.string() }),
+    outputSchema: z.object({ y: z.string() }),
+    permissionScope: "test:read",
+    sideEffectLevel: "read_only",
+    timeoutMs: 1000,
+    async execute(input) {
+      return { y: input.x };
+    },
+  });
+}
+
+describe("ToolRegistry", () => {
+  it("registers and retrieves a tool", () => {
+    const registry = new ToolRegistry();
+    const tool = makeTool("foo");
+    registry.register(tool);
+
+    expect(registry.get("foo")).toBe(tool);
+    expect(registry.has("foo")).toBe(true);
+    expect(registry.size).toBe(1);
+  });
+
+  it("throws DuplicateToolError on duplicate name", () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool("foo"));
+
+    expect(() => registry.register(makeTool("foo"))).toThrow(DuplicateToolError);
+  });
+
+  it("throws ToolNotFoundError for unknown name", () => {
+    const registry = new ToolRegistry();
+
+    expect(() => registry.get("nope")).toThrow(ToolNotFoundError);
+  });
+
+  it("lists all registered tools", () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool("a"));
+    registry.register(makeTool("b"));
+
+    expect(registry.list()).toHaveLength(2);
+  });
+
+  it("toContracts returns metadata without execute", () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool("a"));
+
+    const contracts = registry.toContracts();
+    expect(contracts).toHaveLength(1);
+    expect(contracts[0].name).toBe("a");
+    expect("execute" in contracts[0]).toBe(false);
+  });
+
+  it("toJsonSchemas returns LLM-ready format", () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool("a"));
+
+    const schemas = registry.toJsonSchemas();
+    expect(schemas).toHaveLength(1);
+    expect(schemas[0].name).toBe("a");
+    expect(schemas[0].parameters).toBeDefined();
+  });
+});

--- a/packages/toolkit/src/executor.ts
+++ b/packages/toolkit/src/executor.ts
@@ -1,0 +1,62 @@
+import type { Tool } from "./define-tool.js";
+import type { ToolRegistry } from "./registry.js";
+
+export class ToolTimeoutError extends Error {
+  constructor(
+    public readonly toolName: string,
+    public readonly timeoutMs: number,
+  ) {
+    super(`Tool "${toolName}" timed out after ${timeoutMs}ms`);
+    this.name = "ToolTimeoutError";
+  }
+}
+
+export interface ToolExecutionResult {
+  toolName: string;
+  output: unknown;
+  durationMs: number;
+  attempts: number;
+}
+
+export class ToolExecutor {
+  constructor(private registry: ToolRegistry) {}
+
+  async execute(toolName: string, input: Record<string, unknown>): Promise<ToolExecutionResult> {
+    const tool = this.registry.get(toolName);
+    const maxAttempts = tool.retryPolicy?.maxAttempts ?? 1;
+    const backoffMs = tool.retryPolicy?.backoffMs ?? 0;
+
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const start = performance.now();
+        const output = await withTimeout(tool, input);
+        const durationMs = Math.round(performance.now() - start);
+        return { toolName, output, durationMs, attempts: attempt };
+      } catch (err) {
+        lastError = err;
+        if (attempt < maxAttempts) {
+          await sleep(backoffMs * attempt);
+        }
+      }
+    }
+    throw lastError;
+  }
+}
+
+async function withTimeout(tool: Tool, input: unknown): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new ToolTimeoutError(tool.name, tool.timeoutMs)),
+      tool.timeoutMs,
+    );
+    tool
+      .execute(input)
+      .then(resolve, reject)
+      .finally(() => clearTimeout(timer));
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -17,3 +17,7 @@ export {
   httpFetchTool,
   runShellTool,
 } from "./tools/index.js";
+
+export { ToolRegistry, DuplicateToolError, ToolNotFoundError } from "./registry.js";
+export { ToolExecutor, ToolTimeoutError } from "./executor.js";
+export type { ToolExecutionResult } from "./executor.js";

--- a/packages/toolkit/src/registry.ts
+++ b/packages/toolkit/src/registry.ts
@@ -1,0 +1,57 @@
+import type { Tool, ToolContract } from "./define-tool.js";
+import { toToolContract } from "./define-tool.js";
+
+export class DuplicateToolError extends Error {
+  constructor(public readonly toolName: string) {
+    super(`Tool already registered: ${toolName}`);
+    this.name = "DuplicateToolError";
+  }
+}
+
+export class ToolNotFoundError extends Error {
+  constructor(public readonly toolName: string) {
+    super(`Tool not found: ${toolName}`);
+    this.name = "ToolNotFoundError";
+  }
+}
+
+export class ToolRegistry {
+  private tools = new Map<string, Tool>();
+
+  register(tool: Tool): void {
+    if (this.tools.has(tool.name)) {
+      throw new DuplicateToolError(tool.name);
+    }
+    this.tools.set(tool.name, tool);
+  }
+
+  get(name: string): Tool {
+    const tool = this.tools.get(name);
+    if (!tool) throw new ToolNotFoundError(name);
+    return tool;
+  }
+
+  has(name: string): boolean {
+    return this.tools.has(name);
+  }
+
+  list(): Tool[] {
+    return [...this.tools.values()];
+  }
+
+  toContracts(): ToolContract[] {
+    return this.list().map(toToolContract);
+  }
+
+  toJsonSchemas(): Array<{ name: string; description: string; parameters: Record<string, unknown> }> {
+    return this.list().map((t) => ({
+      name: t.name,
+      description: t.description,
+      parameters: t.inputJsonSchema,
+    }));
+  }
+
+  get size(): number {
+    return this.tools.size;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,10 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18
 
   packages/trace:
     dependencies:


### PR DESCRIPTION
## Summary

- `ToolRegistry`: register/get/list/has + `toContracts()`/`toJsonSchemas()` でLLM連携
- `ToolExecutor`: timeout制御 + retry with exponential backoff
- エラー型: `DuplicateToolError`, `ToolNotFoundError`, `ToolTimeoutError`

## Test plan

- [x] Registry: register, get, duplicate, not found, list, contracts, schemas (6 tests)
- [x] Executor: basic execution, retry on transient failure, retry exhaustion, timeout (4 tests)
- [x] 10 tests all passing

Closes #8