### PR TITLE
feat(policy): implement policy engine with 5 built-in rules

### DIFF
--- a/packages/policy/package.json
+++ b/packages/policy/package.json
@@ -12,6 +12,10 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/policy/src/__tests__/engine.test.ts
+++ b/packages/policy/src/__tests__/engine.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { PolicyEngine } from "../engine.js";
+import { ToolAllowlistRule } from "../rules/tool-allowlist.js";
+import { ScopeRestrictionRule } from "../rules/scope-restriction.js";
+import { CostBudgetRule } from "../rules/cost-budget.js";
+import { StepBudgetRule } from "../rules/step-budget.js";
+import { DangerousActionRule } from "../rules/dangerous-action.js";
+import type { PolicyContext } from "../types.js";
+
+function makeCtx(overrides: Partial<PolicyContext> = {}): PolicyContext {
+  return {
+    toolName: "read_file",
+    permissionScope: "file:read",
+    sideEffectLevel: "read_only",
+    runId: "run_1",
+    currentStepCount: 0,
+    totalCostUsd: 0,
+    ...overrides,
+  };
+}
+
+describe("ToolAllowlistRule", () => {
+  it("allows listed tools", async () => {
+    const rule = new ToolAllowlistRule(new Set(["read_file"]));
+    const result = await rule.evaluate(makeCtx());
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks unlisted tools", async () => {
+    const rule = new ToolAllowlistRule(new Set(["web_search"]));
+    const result = await rule.evaluate(makeCtx());
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("read_file");
+  });
+});
+
+describe("ScopeRestrictionRule", () => {
+  it("allows permitted scopes", async () => {
+    const rule = new ScopeRestrictionRule(new Set(["file:read", "file:write"]));
+    const result = await rule.evaluate(makeCtx());
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks unpermitted scopes", async () => {
+    const rule = new ScopeRestrictionRule(new Set(["network:read"]));
+    const result = await rule.evaluate(makeCtx());
+    expect(result.allowed).toBe(false);
+  });
+});
+
+describe("CostBudgetRule", () => {
+  it("allows within budget", async () => {
+    const rule = new CostBudgetRule(1.0);
+    const result = await rule.evaluate(makeCtx({ totalCostUsd: 0.5 }));
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks over budget", async () => {
+    const rule = new CostBudgetRule(1.0);
+    const result = await rule.evaluate(makeCtx({ totalCostUsd: 1.5 }));
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("exceeded");
+  });
+});
+
+describe("StepBudgetRule", () => {
+  it("allows within step limit", async () => {
+    const rule = new StepBudgetRule(10);
+    const result = await rule.evaluate(makeCtx({ currentStepCount: 5 }));
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks over step limit", async () => {
+    const rule = new StepBudgetRule(10);
+    const result = await rule.evaluate(makeCtx({ currentStepCount: 10 }));
+    expect(result.allowed).toBe(false);
+  });
+});
+
+describe("DangerousActionRule", () => {
+  it("does not require approval for read_only", async () => {
+    const rule = new DangerousActionRule();
+    const result = await rule.evaluate(makeCtx());
+    expect(result.allowed).toBe(true);
+    expect(result.requiresApproval).toBeUndefined();
+  });
+
+  it("requires approval for system_mutation", async () => {
+    const rule = new DangerousActionRule();
+    const result = await rule.evaluate(makeCtx({ sideEffectLevel: "system_mutation" }));
+    expect(result.allowed).toBe(true);
+    expect(result.requiresApproval).toBe(true);
+  });
+
+  it("requires approval for external_write", async () => {
+    const rule = new DangerousActionRule();
+    const result = await rule.evaluate(makeCtx({ sideEffectLevel: "external_write" }));
+    expect(result.requiresApproval).toBe(true);
+  });
+});
+
+describe("PolicyEngine", () => {
+  it("returns allowed when all rules pass", async () => {
+    const engine = new PolicyEngine();
+    engine.addRule(new ToolAllowlistRule(new Set(["read_file"])));
+    engine.addRule(new ScopeRestrictionRule(new Set(["file:read"])));
+
+    const decision = await engine.evaluate(makeCtx());
+    expect(decision.allowed).toBe(true);
+    expect(decision.ruleResults).toHaveLength(2);
+  });
+
+  it("returns blocked when any rule fails", async () => {
+    const engine = new PolicyEngine();
+    engine.addRule(new ToolAllowlistRule(new Set(["web_search"])));
+    engine.addRule(new ScopeRestrictionRule(new Set(["file:read"])));
+
+    const decision = await engine.evaluate(makeCtx());
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toContain("allowlist");
+  });
+
+  it("aggregates requiresApproval from rules", async () => {
+    const engine = new PolicyEngine();
+    engine.addRule(new ToolAllowlistRule(new Set(["run_shell"])));
+    engine.addRule(new DangerousActionRule());
+
+    const decision = await engine.evaluate(
+      makeCtx({ toolName: "run_shell", sideEffectLevel: "system_mutation", permissionScope: "shell:exec" }),
+    );
+    expect(decision.allowed).toBe(true);
+    expect(decision.requiresApproval).toBe(true);
+  });
+
+  it("returns allowed with empty rules", async () => {
+    const engine = new PolicyEngine();
+    const decision = await engine.evaluate(makeCtx());
+    expect(decision.allowed).toBe(true);
+  });
+});

--- a/packages/policy/src/engine.ts
+++ b/packages/policy/src/engine.ts
@@ -1,0 +1,41 @@
+import type { PolicyDecision, RuleResult } from "@agentmesh/core";
+import type { PolicyRule, PolicyContext } from "./types.js";
+
+export class PolicyEngine {
+  private rules: PolicyRule[] = [];
+
+  addRule(rule: PolicyRule): void {
+    this.rules.push(rule);
+  }
+
+  async evaluate(ctx: PolicyContext): Promise<PolicyDecision> {
+    const ruleResults: RuleResult[] = [];
+    let allowed = true;
+    let requiresApproval = false;
+    const reasons: string[] = [];
+
+    for (const rule of this.rules) {
+      const result = await rule.evaluate(ctx);
+      ruleResults.push({
+        ruleName: rule.name,
+        allowed: result.allowed,
+        reason: result.reason,
+      });
+
+      if (!result.allowed) {
+        allowed = false;
+        reasons.push(result.reason);
+      }
+      if (result.requiresApproval) {
+        requiresApproval = true;
+      }
+    }
+
+    return {
+      allowed,
+      ruleResults,
+      requiresApproval,
+      reason: reasons.length > 0 ? reasons.join("; ") : undefined,
+    };
+  }
+}

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -1,2 +1,9 @@
-// TODO: implement
-export {};
+export { PolicyEngine } from "./engine.js";
+export type { PolicyRule, PolicyContext, PolicyRuleResult, Severity } from "./types.js";
+export {
+  ToolAllowlistRule,
+  ScopeRestrictionRule,
+  CostBudgetRule,
+  StepBudgetRule,
+  DangerousActionRule,
+} from "./rules/index.js";

--- a/packages/policy/src/rules/cost-budget.ts
+++ b/packages/policy/src/rules/cost-budget.ts
@@ -1,0 +1,18 @@
+import type { PolicyRule, PolicyContext, PolicyRuleResult } from "../types.js";
+
+export class CostBudgetRule implements PolicyRule {
+  name = "cost_budget";
+
+  constructor(private maxCostUsd: number) {}
+
+  async evaluate(ctx: PolicyContext): Promise<PolicyRuleResult> {
+    if (ctx.totalCostUsd < this.maxCostUsd) {
+      return { allowed: true, severity: "info", reason: "Within cost budget" };
+    }
+    return {
+      allowed: false,
+      severity: "block",
+      reason: `Cost budget exceeded: $${ctx.totalCostUsd.toFixed(4)} >= $${this.maxCostUsd.toFixed(4)}`,
+    };
+  }
+}

--- a/packages/policy/src/rules/dangerous-action.ts
+++ b/packages/policy/src/rules/dangerous-action.ts
@@ -1,0 +1,21 @@
+import type { PolicyRule, PolicyContext, PolicyRuleResult } from "../types.js";
+
+const DANGEROUS_LEVELS = new Set(["external_write", "system_mutation"]);
+
+export class DangerousActionRule implements PolicyRule {
+  name = "dangerous_action";
+
+  constructor(private dangerousLevels: Set<string> = DANGEROUS_LEVELS) {}
+
+  async evaluate(ctx: PolicyContext): Promise<PolicyRuleResult> {
+    if (this.dangerousLevels.has(ctx.sideEffectLevel)) {
+      return {
+        allowed: true,
+        requiresApproval: true,
+        severity: "warn",
+        reason: `Tool "${ctx.toolName}" has side effect level "${ctx.sideEffectLevel}" — approval required`,
+      };
+    }
+    return { allowed: true, severity: "info", reason: "No dangerous action" };
+  }
+}

--- a/packages/policy/src/rules/index.ts
+++ b/packages/policy/src/rules/index.ts
@@ -1,0 +1,5 @@
+export { ToolAllowlistRule } from "./tool-allowlist.js";
+export { ScopeRestrictionRule } from "./scope-restriction.js";
+export { CostBudgetRule } from "./cost-budget.js";
+export { StepBudgetRule } from "./step-budget.js";
+export { DangerousActionRule } from "./dangerous-action.js";

--- a/packages/policy/src/rules/scope-restriction.ts
+++ b/packages/policy/src/rules/scope-restriction.ts
@@ -1,0 +1,18 @@
+import type { PolicyRule, PolicyContext, PolicyRuleResult } from "../types.js";
+
+export class ScopeRestrictionRule implements PolicyRule {
+  name = "scope_restriction";
+
+  constructor(private allowedScopes: Set<string>) {}
+
+  async evaluate(ctx: PolicyContext): Promise<PolicyRuleResult> {
+    if (this.allowedScopes.has(ctx.permissionScope)) {
+      return { allowed: true, severity: "info", reason: "Scope is allowed" };
+    }
+    return {
+      allowed: false,
+      severity: "block",
+      reason: `Scope "${ctx.permissionScope}" is not permitted`,
+    };
+  }
+}

--- a/packages/policy/src/rules/step-budget.ts
+++ b/packages/policy/src/rules/step-budget.ts
@@ -1,0 +1,18 @@
+import type { PolicyRule, PolicyContext, PolicyRuleResult } from "../types.js";
+
+export class StepBudgetRule implements PolicyRule {
+  name = "step_budget";
+
+  constructor(private maxSteps: number) {}
+
+  async evaluate(ctx: PolicyContext): Promise<PolicyRuleResult> {
+    if (ctx.currentStepCount < this.maxSteps) {
+      return { allowed: true, severity: "info", reason: "Within step budget" };
+    }
+    return {
+      allowed: false,
+      severity: "block",
+      reason: `Step budget exceeded: ${ctx.currentStepCount} >= ${this.maxSteps}`,
+    };
+  }
+}

--- a/packages/policy/src/rules/tool-allowlist.ts
+++ b/packages/policy/src/rules/tool-allowlist.ts
@@ -1,0 +1,18 @@
+import type { PolicyRule, PolicyContext, PolicyRuleResult } from "../types.js";
+
+export class ToolAllowlistRule implements PolicyRule {
+  name = "tool_allowlist";
+
+  constructor(private allowedTools: Set<string>) {}
+
+  async evaluate(ctx: PolicyContext): Promise<PolicyRuleResult> {
+    if (this.allowedTools.has(ctx.toolName)) {
+      return { allowed: true, severity: "info", reason: "Tool is allowed" };
+    }
+    return {
+      allowed: false,
+      severity: "block",
+      reason: `Tool "${ctx.toolName}" is not in the allowlist`,
+    };
+  }
+}

--- a/packages/policy/src/types.ts
+++ b/packages/policy/src/types.ts
@@ -1,0 +1,22 @@
+export type Severity = "info" | "warn" | "block";
+
+export interface PolicyContext {
+  toolName: string;
+  permissionScope: string;
+  sideEffectLevel: string;
+  runId: string;
+  currentStepCount: number;
+  totalCostUsd: number;
+}
+
+export interface PolicyRuleResult {
+  allowed: boolean;
+  requiresApproval?: boolean;
+  severity: Severity;
+  reason: string;
+}
+
+export interface PolicyRule {
+  name: string;
+  evaluate(ctx: PolicyContext): Promise<PolicyRuleResult>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,10 @@ importers:
       '@agentmesh/core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18
 
   packages/provider-anthropic:
     dependencies:


### PR DESCRIPTION
## Summary

- `PolicyEngine`: 複数ルールの合成評価（1つでも block → blocked）
- 5つの基本ルール:
  - `ToolAllowlistRule`: 未許可ツール拒否
  - `ScopeRestrictionRule`: 未許可権限拒否
  - `CostBudgetRule`: コスト上限超過で停止
  - `StepBudgetRule`: ステップ上限超過で停止
  - `DangerousActionRule`: external_write/system_mutation は approval 要求

## Test plan

- [x] 各ルール個別テスト (11 tests)
- [x] Engine 合成テスト: all pass, any block, approval aggregation, empty rules (4 tests)
- [x] 15 tests all passing

Closes #9