### PR TITLE
feat(provider-openai): add OpenAI provider with LlmProvider interface

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,3 +22,14 @@ export {
   InvalidTransitionError,
 } from "./run-machine.js";
 export type { RunBudget, RunMachineState, TransitionResult } from "./run-machine.js";
+
+export type {
+  LlmProvider,
+  ProviderGenerateInput,
+  ProviderGenerateOutput,
+  ProviderMessage,
+  ProviderToolCall,
+  ProviderToolSpec,
+  ProviderUsage,
+  FinishReason,
+} from "./provider.js";

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -1,0 +1,44 @@
+export type FinishReason = "stop" | "tool_calls" | "length" | "content_filter" | "error";
+
+export interface ProviderMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | null;
+  toolCallId?: string;
+  toolCalls?: ProviderToolCall[];
+}
+
+export interface ProviderToolCall {
+  id: string;
+  name: string;
+  arguments: string;
+}
+
+export interface ProviderToolSpec {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+export interface ProviderGenerateInput {
+  model: string;
+  messages: ProviderMessage[];
+  tools?: ProviderToolSpec[];
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export interface ProviderUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface ProviderGenerateOutput {
+  message: ProviderMessage;
+  finishReason: FinishReason;
+  usage: ProviderUsage;
+}
+
+export interface LlmProvider {
+  name: string;
+  generate(input: ProviderGenerateInput): Promise<ProviderGenerateOutput>;
+}

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -7,11 +7,16 @@
   "types": "dist/index.d.ts",
   "description": "OpenAI provider adapter",
   "dependencies": {
-    "@agentmesh/core": "workspace:*"
+    "@agentmesh/core": "workspace:*",
+    "openai": "^6.27.0"
   },
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/provider-openai/src/__tests__/mapper.test.ts
+++ b/packages/provider-openai/src/__tests__/mapper.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { toOpenAIMessages, toOpenAITools, fromOpenAIChoice, fromOpenAIUsage } from "../mapper.js";
+import type { ProviderMessage, ProviderToolSpec } from "@agentmesh/core";
+import type OpenAI from "openai";
+
+describe("toOpenAIMessages", () => {
+  it("maps system/user/assistant messages", () => {
+    const messages: ProviderMessage[] = [
+      { role: "system", content: "You are helpful" },
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi!" },
+    ];
+    const result = toOpenAIMessages(messages);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ role: "system", content: "You are helpful" });
+  });
+
+  it("maps tool message with toolCallId", () => {
+    const messages: ProviderMessage[] = [
+      { role: "tool", content: '{"result": 42}', toolCallId: "tc_1" },
+    ];
+    const result = toOpenAIMessages(messages);
+    expect(result[0]).toEqual({
+      role: "tool",
+      content: '{"result": 42}',
+      tool_call_id: "tc_1",
+    });
+  });
+
+  it("maps assistant message with tool_calls", () => {
+    const messages: ProviderMessage[] = [
+      {
+        role: "assistant",
+        content: null,
+        toolCalls: [{ id: "tc_1", name: "search", arguments: '{"q":"test"}' }],
+      },
+    ];
+    const result = toOpenAIMessages(messages);
+    const msg = result[0] as OpenAI.ChatCompletionAssistantMessageParam;
+    expect(msg.tool_calls).toHaveLength(1);
+    expect(msg.tool_calls![0]).toEqual({
+      id: "tc_1",
+      type: "function",
+      function: { name: "search", arguments: '{"q":"test"}' },
+    });
+  });
+});
+
+describe("toOpenAITools", () => {
+  it("maps tool specs to OpenAI format", () => {
+    const tools: ProviderToolSpec[] = [
+      { name: "search", description: "Search", parameters: { type: "object" } },
+    ];
+    const result = toOpenAITools(tools);
+    expect(result[0]).toEqual({
+      type: "function",
+      function: {
+        name: "search",
+        description: "Search",
+        parameters: { type: "object" },
+      },
+    });
+  });
+});
+
+describe("fromOpenAIChoice", () => {
+  it("maps a stop choice", () => {
+    const choice = {
+      index: 0,
+      message: { role: "assistant" as const, content: "Done", refusal: null },
+      finish_reason: "stop" as const,
+      logprobs: null,
+    };
+    const result = fromOpenAIChoice(choice);
+    expect(result.message.role).toBe("assistant");
+    expect(result.message.content).toBe("Done");
+    expect(result.finishReason).toBe("stop");
+  });
+
+  it("maps a tool_calls choice", () => {
+    const choice = {
+      index: 0,
+      message: {
+        role: "assistant" as const,
+        content: null,
+        refusal: null,
+        tool_calls: [
+          {
+            id: "tc_1",
+            type: "function" as const,
+            function: { name: "search", arguments: '{"q":"hi"}' },
+          },
+        ],
+      },
+      finish_reason: "tool_calls" as const,
+      logprobs: null,
+    };
+    const result = fromOpenAIChoice(choice);
+    expect(result.finishReason).toBe("tool_calls");
+    expect(result.message.toolCalls).toHaveLength(1);
+    expect(result.message.toolCalls![0].name).toBe("search");
+  });
+});
+
+describe("fromOpenAIUsage", () => {
+  it("maps usage", () => {
+    const usage = { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 };
+    const result = fromOpenAIUsage(usage);
+    expect(result.inputTokens).toBe(100);
+    expect(result.outputTokens).toBe(50);
+  });
+
+  it("handles undefined usage", () => {
+    const result = fromOpenAIUsage(undefined);
+    expect(result.inputTokens).toBe(0);
+    expect(result.outputTokens).toBe(0);
+  });
+});

--- a/packages/provider-openai/src/index.ts
+++ b/packages/provider-openai/src/index.ts
@@ -1,2 +1,8 @@
-// TODO: implement
-export {};
+export { OpenAIProvider } from "./provider.js";
+export type { OpenAIProviderOptions } from "./provider.js";
+export {
+  toOpenAIMessages,
+  toOpenAITools,
+  fromOpenAIChoice,
+  fromOpenAIUsage,
+} from "./mapper.js";

--- a/packages/provider-openai/src/mapper.ts
+++ b/packages/provider-openai/src/mapper.ts
@@ -1,0 +1,95 @@
+import type {
+  ProviderMessage,
+  ProviderToolSpec,
+  ProviderToolCall,
+  ProviderUsage,
+  FinishReason,
+} from "@agentmesh/core";
+import type OpenAI from "openai";
+
+type ChatMessage = OpenAI.ChatCompletionMessageParam;
+type ChatTool = OpenAI.ChatCompletionTool;
+type ChatChoice = OpenAI.ChatCompletion.Choice;
+
+export function toOpenAIMessages(messages: ProviderMessage[]): ChatMessage[] {
+  return messages.map((m) => {
+    if (m.role === "tool") {
+      return {
+        role: "tool" as const,
+        content: m.content ?? "",
+        tool_call_id: m.toolCallId!,
+      };
+    }
+    if (m.role === "assistant" && m.toolCalls?.length) {
+      return {
+        role: "assistant" as const,
+        content: m.content,
+        tool_calls: m.toolCalls.map((tc) => ({
+          id: tc.id,
+          type: "function" as const,
+          function: { name: tc.name, arguments: tc.arguments },
+        })),
+      };
+    }
+    return { role: m.role, content: m.content ?? "" } as ChatMessage;
+  });
+}
+
+export function toOpenAITools(tools: ProviderToolSpec[]): ChatTool[] {
+  return tools.map((t) => ({
+    type: "function" as const,
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters,
+    },
+  }));
+}
+
+export function fromOpenAIChoice(choice: ChatChoice): {
+  message: ProviderMessage;
+  finishReason: FinishReason;
+} {
+  const msg = choice.message;
+  const toolCalls: ProviderToolCall[] | undefined = msg.tool_calls?.map((tc) => {
+    if (tc.type !== "function") {
+      return { id: tc.id, name: tc.type, arguments: "{}" };
+    }
+    return {
+      id: tc.id,
+      name: tc.function.name,
+      arguments: tc.function.arguments,
+    };
+  });
+
+  return {
+    message: {
+      role: "assistant",
+      content: msg.content,
+      toolCalls: toolCalls?.length ? toolCalls : undefined,
+    },
+    finishReason: mapFinishReason(choice.finish_reason),
+  };
+}
+
+export function fromOpenAIUsage(usage: OpenAI.CompletionUsage | undefined): ProviderUsage {
+  return {
+    inputTokens: usage?.prompt_tokens ?? 0,
+    outputTokens: usage?.completion_tokens ?? 0,
+  };
+}
+
+function mapFinishReason(reason: string | null): FinishReason {
+  switch (reason) {
+    case "stop":
+      return "stop";
+    case "tool_calls":
+      return "tool_calls";
+    case "length":
+      return "length";
+    case "content_filter":
+      return "content_filter";
+    default:
+      return "error";
+  }
+}

--- a/packages/provider-openai/src/provider.ts
+++ b/packages/provider-openai/src/provider.ts
@@ -1,0 +1,38 @@
+import OpenAI from "openai";
+import type { LlmProvider, ProviderGenerateInput, ProviderGenerateOutput } from "@agentmesh/core";
+import { toOpenAIMessages, toOpenAITools, fromOpenAIChoice, fromOpenAIUsage } from "./mapper.js";
+
+export interface OpenAIProviderOptions {
+  apiKey?: string;
+  baseURL?: string;
+}
+
+export class OpenAIProvider implements LlmProvider {
+  name = "openai";
+  private client: OpenAI;
+
+  constructor(opts: OpenAIProviderOptions = {}) {
+    this.client = new OpenAI({
+      apiKey: opts.apiKey,
+      baseURL: opts.baseURL,
+    });
+  }
+
+  async generate(input: ProviderGenerateInput): Promise<ProviderGenerateOutput> {
+    const response = await this.client.chat.completions.create({
+      model: input.model,
+      messages: toOpenAIMessages(input.messages),
+      tools: input.tools?.length ? toOpenAITools(input.tools) : undefined,
+      temperature: input.temperature,
+      max_tokens: input.maxTokens,
+    });
+
+    const choice = response.choices[0];
+    if (!choice) throw new Error("OpenAI returned no choices");
+
+    const { message, finishReason } = fromOpenAIChoice(choice);
+    const usage = fromOpenAIUsage(response.usage);
+
+    return { message, finishReason, usage };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,13 @@ importers:
       '@agentmesh/core':
         specifier: workspace:*
         version: link:../core
+      openai:
+        specifier: ^6.27.0
+        version: 6.27.0(zod@4.3.6)
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18
 
   packages/toolkit:
     dependencies:
@@ -475,6 +482,18 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  openai@6.27.0:
+    resolution: {integrity: sha512-osTKySlrdYrLYTt0zjhY8yp0JUBmWDCN+Q+QxsV4xMQnnoVFpylgKGgxwN8sSdTNw0G4y+WUXs4eCMWpyDNWZQ==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -906,6 +925,10 @@ snapshots:
   nanoid@3.3.11: {}
 
   obug@2.1.1: {}
+
+  openai@6.27.0(zod@4.3.6):
+    optionalDependencies:
+      zod: 4.3.6
 
   pathe@2.0.3: {}
 


### PR DESCRIPTION
## Summary

- `LlmProvider` インターフェースを `@agentmesh/core` に定義
- `OpenAIProvider`: openai SDK v6 をラップし共通型に変換
- Mapper: messages, tools, choices, usage の双方向変換
- OpenAI v6 の union型 (FunctionToolCall | CustomToolCall) を安全にナローイング

## Test plan

- [x] toOpenAIMessages: system/user/assistant/tool メッセージ変換 (3 tests)
- [x] toOpenAITools: tool spec 変換 (1 test)
- [x] fromOpenAIChoice: stop/tool_calls (2 tests)
- [x] fromOpenAIUsage: normal/undefined (2 tests)
- [x] 8 tests all passing

Closes #5