### PR TITLE
feat(provider-anthropic): add Anthropic provider adapter

### DIFF
--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -7,11 +7,16 @@
   "types": "dist/index.d.ts",
   "description": "Anthropic provider adapter",
   "dependencies": {
-    "@agentmesh/core": "workspace:*"
+    "@agentmesh/core": "workspace:*",
+    "@anthropic-ai/sdk": "^0.78.0"
   },
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/provider-anthropic/src/__tests__/mapper.test.ts
+++ b/packages/provider-anthropic/src/__tests__/mapper.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractSystemMessage,
+  toAnthropicMessages,
+  toAnthropicTools,
+  fromAnthropicResponse,
+} from "../mapper.js";
+import type { ProviderMessage, ProviderToolSpec } from "@agentmesh/core";
+import type Anthropic from "@anthropic-ai/sdk";
+
+describe("extractSystemMessage", () => {
+  it("extracts system messages and returns rest", () => {
+    const messages: ProviderMessage[] = [
+      { role: "system", content: "Be helpful" },
+      { role: "user", content: "Hello" },
+    ];
+    const result = extractSystemMessage(messages);
+    expect(result.system).toBe("Be helpful");
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe("user");
+  });
+
+  it("returns undefined system when no system message", () => {
+    const messages: ProviderMessage[] = [{ role: "user", content: "Hi" }];
+    const result = extractSystemMessage(messages);
+    expect(result.system).toBeUndefined();
+  });
+
+  it("joins multiple system messages", () => {
+    const messages: ProviderMessage[] = [
+      { role: "system", content: "Rule 1" },
+      { role: "system", content: "Rule 2" },
+      { role: "user", content: "Go" },
+    ];
+    const result = extractSystemMessage(messages);
+    expect(result.system).toBe("Rule 1\nRule 2");
+  });
+});
+
+describe("toAnthropicMessages", () => {
+  it("maps user and assistant messages", () => {
+    const messages: ProviderMessage[] = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi!" },
+    ];
+    const result = toAnthropicMessages(messages);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ role: "user", content: "Hello" });
+  });
+
+  it("maps assistant with tool_calls to content blocks", () => {
+    const messages: ProviderMessage[] = [
+      {
+        role: "assistant",
+        content: "Let me search",
+        toolCalls: [{ id: "tu_1", name: "search", arguments: '{"q":"test"}' }],
+      },
+    ];
+    const result = toAnthropicMessages(messages);
+    const msg = result[0] as { role: string; content: unknown[] };
+    expect(msg.content).toHaveLength(2);
+    expect(msg.content[0]).toEqual({ type: "text", text: "Let me search" });
+    expect(msg.content[1]).toEqual({
+      type: "tool_use",
+      id: "tu_1",
+      name: "search",
+      input: { q: "test" },
+    });
+  });
+
+  it("maps tool result as user message", () => {
+    const messages: ProviderMessage[] = [
+      { role: "tool", content: '{"data": 42}', toolCallId: "tu_1" },
+    ];
+    const result = toAnthropicMessages(messages);
+    expect(result[0].role).toBe("user");
+    const content = (result[0] as { content: unknown[] }).content;
+    expect(content[0]).toEqual({
+      type: "tool_result",
+      tool_use_id: "tu_1",
+      content: '{"data": 42}',
+    });
+  });
+});
+
+describe("toAnthropicTools", () => {
+  it("maps tool specs", () => {
+    const tools: ProviderToolSpec[] = [
+      { name: "search", description: "Search", parameters: { type: "object" } },
+    ];
+    const result = toAnthropicTools(tools);
+    expect(result[0]).toEqual({
+      name: "search",
+      description: "Search",
+      input_schema: { type: "object" },
+    });
+  });
+});
+
+describe("fromAnthropicResponse", () => {
+  it("maps text response", () => {
+    const response = {
+      id: "msg_1",
+      type: "message" as const,
+      role: "assistant" as const,
+      model: "claude-sonnet-4-20250514",
+      content: [{ type: "text" as const, text: "Hello!" }],
+      stop_reason: "end_turn" as const,
+      stop_sequence: null,
+      usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+    } as Anthropic.Message;
+    const result = fromAnthropicResponse(response);
+    expect(result.message.content).toBe("Hello!");
+    expect(result.finishReason).toBe("stop");
+    expect(result.usage).toEqual({ inputTokens: 10, outputTokens: 5 });
+  });
+
+  it("maps tool_use response", () => {
+    const response = {
+      id: "msg_2",
+      type: "message" as const,
+      role: "assistant" as const,
+      model: "claude-sonnet-4-20250514",
+      content: [
+        { type: "text" as const, text: "Searching..." },
+        { type: "tool_use" as const, id: "tu_1", name: "search", input: { q: "test" } },
+      ],
+      stop_reason: "tool_use" as const,
+      stop_sequence: null,
+      usage: { input_tokens: 20, output_tokens: 15, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+    } as Anthropic.Message;
+    const result = fromAnthropicResponse(response);
+    expect(result.finishReason).toBe("tool_calls");
+    expect(result.message.toolCalls).toHaveLength(1);
+    expect(result.message.toolCalls![0]).toEqual({
+      id: "tu_1",
+      name: "search",
+      arguments: '{"q":"test"}',
+    });
+    expect(result.message.content).toBe("Searching...");
+  });
+
+  it("maps max_tokens stop reason", () => {
+    const response = {
+      id: "msg_3",
+      type: "message" as const,
+      role: "assistant" as const,
+      model: "claude-sonnet-4-20250514",
+      content: [{ type: "text" as const, text: "Truncated..." }],
+      stop_reason: "max_tokens" as const,
+      stop_sequence: null,
+      usage: { input_tokens: 5, output_tokens: 100, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+    } as Anthropic.Message;
+    const result = fromAnthropicResponse(response);
+    expect(result.finishReason).toBe("length");
+  });
+});

--- a/packages/provider-anthropic/src/index.ts
+++ b/packages/provider-anthropic/src/index.ts
@@ -1,2 +1,8 @@
-// TODO: implement
-export {};
+export { AnthropicProvider } from "./provider.js";
+export type { AnthropicProviderOptions } from "./provider.js";
+export {
+  extractSystemMessage,
+  toAnthropicMessages,
+  toAnthropicTools,
+  fromAnthropicResponse,
+} from "./mapper.js";

--- a/packages/provider-anthropic/src/mapper.ts
+++ b/packages/provider-anthropic/src/mapper.ts
@@ -1,0 +1,113 @@
+import type {
+  ProviderMessage,
+  ProviderToolSpec,
+  ProviderToolCall,
+  ProviderUsage,
+  FinishReason,
+} from "@agentmesh/core";
+import type Anthropic from "@anthropic-ai/sdk";
+
+type MessageParam = Anthropic.MessageCreateParams["messages"][number];
+type ToolParam = Anthropic.Tool;
+type ContentBlock = Anthropic.ContentBlock;
+type MessageResponse = Anthropic.Message;
+
+export function extractSystemMessage(
+  messages: ProviderMessage[],
+): { system: string | undefined; messages: ProviderMessage[] } {
+  const systemMsgs = messages.filter((m) => m.role === "system");
+  const rest = messages.filter((m) => m.role !== "system");
+  const system = systemMsgs.map((m) => m.content ?? "").join("\n") || undefined;
+  return { system, messages: rest };
+}
+
+export function toAnthropicMessages(messages: ProviderMessage[]): MessageParam[] {
+  return messages.map((m) => {
+    if (m.role === "assistant" && m.toolCalls?.length) {
+      const content: Anthropic.ContentBlockParam[] = [];
+      if (m.content) {
+        content.push({ type: "text", text: m.content });
+      }
+      for (const tc of m.toolCalls) {
+        content.push({
+          type: "tool_use",
+          id: tc.id,
+          name: tc.name,
+          input: JSON.parse(tc.arguments),
+        });
+      }
+      return { role: "assistant" as const, content };
+    }
+
+    if (m.role === "tool") {
+      return {
+        role: "user" as const,
+        content: [
+          {
+            type: "tool_result" as const,
+            tool_use_id: m.toolCallId!,
+            content: m.content ?? "",
+          },
+        ],
+      };
+    }
+
+    return { role: m.role as "user" | "assistant", content: m.content ?? "" };
+  });
+}
+
+export function toAnthropicTools(tools: ProviderToolSpec[]): ToolParam[] {
+  return tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    input_schema: t.parameters as Anthropic.Tool.InputSchema,
+  }));
+}
+
+export function fromAnthropicResponse(response: MessageResponse): {
+  message: ProviderMessage;
+  finishReason: FinishReason;
+  usage: ProviderUsage;
+} {
+  const toolCalls = extractToolCalls(response.content);
+  const textContent = response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("");
+
+  return {
+    message: {
+      role: "assistant",
+      content: textContent || null,
+      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    },
+    finishReason: mapStopReason(response.stop_reason),
+    usage: {
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+    },
+  };
+}
+
+function extractToolCalls(blocks: ContentBlock[]): ProviderToolCall[] {
+  return blocks
+    .filter((b): b is Anthropic.ToolUseBlock => b.type === "tool_use")
+    .map((b) => ({
+      id: b.id,
+      name: b.name,
+      arguments: JSON.stringify(b.input),
+    }));
+}
+
+function mapStopReason(reason: string | null): FinishReason {
+  switch (reason) {
+    case "end_turn":
+      return "stop";
+    case "tool_use":
+      return "tool_calls";
+    case "max_tokens":
+      return "length";
+    default:
+      return "error";
+  }
+}

--- a/packages/provider-anthropic/src/provider.ts
+++ b/packages/provider-anthropic/src/provider.ts
@@ -1,0 +1,40 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { LlmProvider, ProviderGenerateInput, ProviderGenerateOutput } from "@agentmesh/core";
+import {
+  extractSystemMessage,
+  toAnthropicMessages,
+  toAnthropicTools,
+  fromAnthropicResponse,
+} from "./mapper.js";
+
+export interface AnthropicProviderOptions {
+  apiKey?: string;
+  baseURL?: string;
+}
+
+export class AnthropicProvider implements LlmProvider {
+  name = "anthropic";
+  private client: Anthropic;
+
+  constructor(opts: AnthropicProviderOptions = {}) {
+    this.client = new Anthropic({
+      apiKey: opts.apiKey,
+      baseURL: opts.baseURL,
+    });
+  }
+
+  async generate(input: ProviderGenerateInput): Promise<ProviderGenerateOutput> {
+    const { system, messages } = extractSystemMessage(input.messages);
+
+    const response = await this.client.messages.create({
+      model: input.model,
+      system: system,
+      messages: toAnthropicMessages(messages),
+      tools: input.tools?.length ? toAnthropicTools(input.tools) : undefined,
+      temperature: input.temperature,
+      max_tokens: input.maxTokens ?? 4096,
+    });
+
+    return fromAnthropicResponse(response);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,13 @@ importers:
       '@agentmesh/core':
         specifier: workspace:*
         version: link:../core
+      '@anthropic-ai/sdk':
+        specifier: ^0.78.0
+        version: 0.78.0(zod@4.3.6)
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18
 
   packages/provider-openai:
     dependencies:
@@ -109,6 +116,19 @@ importers:
         version: link:../core
 
 packages:
+
+  '@anthropic-ai/sdk@0.78.0':
+    resolution: {integrity: sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -472,6 +492,10 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -541,6 +565,9 @@ packages:
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   turbo-darwin-64@2.8.16:
     resolution: {integrity: sha512-KWa4hUMWrpADC6Q/wIHRkBLw6X6MV9nx6X7hSXbTrrMz0KdaKhmfudUZ3sS76bJFmgArBU25cSc0AUyyrswYxg==}
@@ -664,6 +691,14 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@anthropic-ai/sdk@0.78.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
+  '@babel/runtime@7.28.6': {}
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -918,6 +953,11 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      ts-algebra: 2.0.0
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -991,6 +1031,8 @@ snapshots:
       picomatch: 4.0.3
 
   tinyrainbow@3.0.3: {}
+
+  ts-algebra@2.0.0: {}
 
   turbo-darwin-64@2.8.16:
     optional: true


### PR DESCRIPTION
## Summary

- `AnthropicProvider`: @anthropic-ai/sdk v0.78 をラップし LlmProvider に適合
- Anthropic 固有の差分吸収:
  - system message → 別パラメータに分離
  - tool_use content block ↔ ProviderToolCall 相互変換
  - tool_result を user ロールにマッピング
  - stop_reason (end_turn/tool_use/max_tokens) → FinishReason 正規化

## Test plan

- [x] extractSystemMessage: 抽出, undefined, 複数結合 (3 tests)
- [x] toAnthropicMessages: user/assistant, tool_calls, tool_result (3 tests)
- [x] toAnthropicTools: spec変換 (1 test)
- [x] fromAnthropicResponse: text, tool_use, max_tokens (3 tests)
- [x] 10 tests all passing

Closes #6