### PR TITLE
feat(core): implement step executor

### DIFF
--- a/packages/core/src/__tests__/step-executor.test.ts
+++ b/packages/core/src/__tests__/step-executor.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { StepExecutor, _resetStepEventSeq } from "../step-executor.js";
+import type { ToolHandler, PolicyChecker, StepInput } from "../step-executor.js";
+import type { LlmProvider, ProviderGenerateOutput, ProviderToolSpec } from "../provider.js";
+
+beforeEach(() => {
+  _resetStepEventSeq();
+});
+
+function makeInput(overrides: Partial<StepInput> = {}): StepInput {
+  return {
+    runId: "run_1",
+    stepIndex: 0,
+    model: "test-model",
+    messages: [{ role: "user", content: "Hello" }],
+    currentStepCount: 0,
+    totalCostUsd: 0,
+    ...overrides,
+  };
+}
+
+function makeProvider(output: ProviderGenerateOutput): LlmProvider {
+  return {
+    name: "mock",
+    generate: async () => output,
+  };
+}
+
+function makeToolHandler(results: Record<string, unknown> = {}): ToolHandler {
+  return {
+    execute: async (name, _input) => ({
+      output: results[name] ?? { result: "ok" },
+      durationMs: 10,
+    }),
+    toToolSpecs: () => [
+      { name: "search", description: "Search", parameters: { type: "object" } },
+    ] as ProviderToolSpec[],
+  };
+}
+
+describe("StepExecutor", () => {
+  it("handles simple text response (no tool calls)", async () => {
+    const provider = makeProvider({
+      message: { role: "assistant", content: "Hi there!" },
+      finishReason: "stop",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+    const executor = new StepExecutor(provider, makeToolHandler());
+
+    const result = await executor.execute(makeInput());
+
+    expect(result.finishReason).toBe("stop");
+    expect(result.toolCallResults).toHaveLength(0);
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[1].content).toBe("Hi there!");
+    expect(result.events.some((e) => e.eventType === "step.started")).toBe(true);
+    expect(result.events.some((e) => e.eventType === "llm.called")).toBe(true);
+    expect(result.events.some((e) => e.eventType === "llm.responded")).toBe(true);
+  });
+
+  it("executes tool calls and appends results", async () => {
+    const provider = makeProvider({
+      message: {
+        role: "assistant",
+        content: null,
+        toolCalls: [{ id: "tc_1", name: "search", arguments: '{"q":"test"}' }],
+      },
+      finishReason: "tool_calls",
+      usage: { inputTokens: 15, outputTokens: 10 },
+    });
+    const toolHandler = makeToolHandler({ search: { results: ["a", "b"] } });
+    const executor = new StepExecutor(provider, toolHandler);
+
+    const result = await executor.execute(makeInput());
+
+    expect(result.finishReason).toBe("tool_calls");
+    expect(result.toolCallResults).toHaveLength(1);
+    expect(result.toolCallResults[0].status).toBe("succeeded");
+    expect(result.toolCallResults[0].output).toEqual({ results: ["a", "b"] });
+    // messages: user + assistant + tool result
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[2].role).toBe("tool");
+    expect(result.events.some((e) => e.eventType === "tool.requested")).toBe(true);
+    expect(result.events.some((e) => e.eventType === "tool.completed")).toBe(true);
+  });
+
+  it("handles tool execution error", async () => {
+    const provider = makeProvider({
+      message: {
+        role: "assistant",
+        content: null,
+        toolCalls: [{ id: "tc_1", name: "search", arguments: '{"q":"fail"}' }],
+      },
+      finishReason: "tool_calls",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+    const toolHandler: ToolHandler = {
+      execute: async () => { throw new Error("timeout"); },
+      toToolSpecs: () => [],
+    };
+    const executor = new StepExecutor(provider, toolHandler);
+
+    const result = await executor.execute(makeInput());
+
+    expect(result.toolCallResults[0].status).toBe("failed");
+    expect(result.toolCallResults[0].error).toBe("timeout");
+    expect(result.messages[2].role).toBe("tool");
+    expect(result.messages[2].content).toContain("timeout");
+  });
+
+  it("handles LLM provider error", async () => {
+    const provider: LlmProvider = {
+      name: "mock",
+      generate: async () => { throw new Error("rate limited"); },
+    };
+    const executor = new StepExecutor(provider, makeToolHandler());
+
+    const result = await executor.execute(makeInput());
+
+    expect(result.finishReason).toBe("error");
+    expect(result.events.some((e) => e.eventType === "step.failed")).toBe(true);
+  });
+
+  it("blocks tool call when policy denies", async () => {
+    const provider = makeProvider({
+      message: {
+        role: "assistant",
+        content: null,
+        toolCalls: [{ id: "tc_1", name: "search", arguments: '{}' }],
+      },
+      finishReason: "tool_calls",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+    const policyChecker: PolicyChecker = {
+      evaluate: async () => ({ allowed: false, requiresApproval: false, reason: "not in allowlist" }),
+    };
+    const executor = new StepExecutor(provider, makeToolHandler(), policyChecker);
+
+    const result = await executor.execute(makeInput());
+
+    expect(result.blocked).toBe(true);
+    expect(result.toolCallResults[0].status).toBe("blocked");
+    expect(result.events.some((e) => e.eventType === "policy.checked")).toBe(true);
+  });
+
+  it("sets requiresApproval when policy demands it", async () => {
+    const provider = makeProvider({
+      message: {
+        role: "assistant",
+        content: null,
+        toolCalls: [{ id: "tc_1", name: "search", arguments: '{}' }],
+      },
+      finishReason: "tool_calls",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+    const policyChecker: PolicyChecker = {
+      evaluate: async () => ({ allowed: true, requiresApproval: true }),
+    };
+    const executor = new StepExecutor(provider, makeToolHandler(), policyChecker);
+
+    const result = await executor.execute(makeInput());
+
+    expect(result.requiresApproval).toBe(true);
+    expect(result.toolCallResults[0].status).toBe("blocked");
+    expect(result.toolCallResults[0].error).toBe("Requires approval");
+  });
+
+  it("works without policy checker", async () => {
+    const provider = makeProvider({
+      message: {
+        role: "assistant",
+        content: null,
+        toolCalls: [{ id: "tc_1", name: "search", arguments: '{}' }],
+      },
+      finishReason: "tool_calls",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+    const executor = new StepExecutor(provider, makeToolHandler());
+
+    const result = await executor.execute(makeInput());
+
+    expect(result.toolCallResults[0].status).toBe("succeeded");
+    expect(result.blocked).toBe(false);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,3 +33,12 @@ export type {
   ProviderUsage,
   FinishReason,
 } from "./provider.js";
+
+export { StepExecutor } from "./step-executor.js";
+export type {
+  ToolHandler,
+  PolicyChecker,
+  StepInput,
+  StepOutput,
+  ToolCallResult,
+} from "./step-executor.js";

--- a/packages/core/src/step-executor.ts
+++ b/packages/core/src/step-executor.ts
@@ -1,0 +1,247 @@
+import type {
+  LlmProvider,
+  ProviderMessage,
+  ProviderToolSpec,
+  ProviderGenerateOutput,
+  ProviderUsage,
+  FinishReason,
+} from "./provider.js";
+import type { ExecutionEvent, EventType } from "./schema/event.js";
+
+export interface ToolHandler {
+  execute(toolName: string, input: Record<string, unknown>): Promise<{ output: unknown; durationMs: number }>;
+  toToolSpecs(): ProviderToolSpec[];
+}
+
+export interface PolicyChecker {
+  evaluate(ctx: {
+    toolName: string;
+    permissionScope: string;
+    sideEffectLevel: string;
+    runId: string;
+    currentStepCount: number;
+    totalCostUsd: number;
+  }): Promise<{ allowed: boolean; requiresApproval: boolean; reason?: string }>;
+}
+
+export interface StepInput {
+  runId: string;
+  stepIndex: number;
+  model: string;
+  messages: ProviderMessage[];
+  currentStepCount: number;
+  totalCostUsd: number;
+}
+
+export interface StepOutput {
+  messages: ProviderMessage[];
+  finishReason: FinishReason;
+  usage: ProviderUsage;
+  toolCallResults: ToolCallResult[];
+  events: ExecutionEvent[];
+  blocked: boolean;
+  requiresApproval: boolean;
+}
+
+export interface ToolCallResult {
+  toolName: string;
+  input: Record<string, unknown>;
+  output: unknown;
+  durationMs: number;
+  status: "succeeded" | "failed" | "blocked";
+  error?: string;
+}
+
+let eventSeq = 0;
+
+function emitEvent(
+  runId: string,
+  stepId: string | null,
+  eventType: EventType,
+  payload: Record<string, unknown> = {},
+): ExecutionEvent {
+  return {
+    id: `evt_${++eventSeq}`,
+    runId,
+    stepId,
+    eventType,
+    payload,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export class StepExecutor {
+  constructor(
+    private provider: LlmProvider,
+    private toolHandler: ToolHandler,
+    private policyChecker?: PolicyChecker,
+  ) {}
+
+  async execute(input: StepInput): Promise<StepOutput> {
+    const stepId = `step_${input.runId}_${input.stepIndex}`;
+    const events: ExecutionEvent[] = [];
+    const toolCallResults: ToolCallResult[] = [];
+    let blocked = false;
+    let requiresApproval = false;
+
+    events.push(emitEvent(input.runId, stepId, "step.started", { index: input.stepIndex }));
+
+    // 1. Call LLM
+    events.push(emitEvent(input.runId, stepId, "llm.called", { model: input.model }));
+
+    let llmOutput: ProviderGenerateOutput;
+    try {
+      llmOutput = await this.provider.generate({
+        model: input.model,
+        messages: input.messages,
+        tools: this.toolHandler.toToolSpecs(),
+      });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      events.push(emitEvent(input.runId, stepId, "step.failed", { error }));
+      return {
+        messages: input.messages,
+        finishReason: "error",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        toolCallResults: [],
+        events,
+        blocked: false,
+        requiresApproval: false,
+      };
+    }
+
+    events.push(emitEvent(input.runId, stepId, "llm.responded", {
+      finishReason: llmOutput.finishReason,
+      usage: llmOutput.usage,
+    }));
+
+    const updatedMessages = [...input.messages, llmOutput.message];
+
+    // 2. If no tool calls, return
+    if (llmOutput.finishReason !== "tool_calls" || !llmOutput.message.toolCalls?.length) {
+      return {
+        messages: updatedMessages,
+        finishReason: llmOutput.finishReason,
+        usage: llmOutput.usage,
+        toolCallResults: [],
+        events,
+        blocked: false,
+        requiresApproval: false,
+      };
+    }
+
+    // 3. Process tool calls
+    const toolMessages: ProviderMessage[] = [];
+
+    for (const tc of llmOutput.message.toolCalls) {
+      const parsedInput = JSON.parse(tc.arguments) as Record<string, unknown>;
+
+      events.push(emitEvent(input.runId, stepId, "tool.requested", { toolName: tc.name, input: parsedInput }));
+
+      // 3a. Policy check
+      if (this.policyChecker) {
+        const decision = await this.policyChecker.evaluate({
+          toolName: tc.name,
+          permissionScope: "",
+          sideEffectLevel: "",
+          runId: input.runId,
+          currentStepCount: input.currentStepCount,
+          totalCostUsd: input.totalCostUsd,
+        });
+
+        events.push(emitEvent(input.runId, stepId, "policy.checked", {
+          toolName: tc.name,
+          allowed: decision.allowed,
+          requiresApproval: decision.requiresApproval,
+        }));
+
+        if (!decision.allowed) {
+          blocked = true;
+          toolCallResults.push({
+            toolName: tc.name,
+            input: parsedInput,
+            output: null,
+            durationMs: 0,
+            status: "blocked",
+            error: decision.reason,
+          });
+          toolMessages.push({
+            role: "tool",
+            content: JSON.stringify({ error: `Policy blocked: ${decision.reason}` }),
+            toolCallId: tc.id,
+          });
+          continue;
+        }
+
+        if (decision.requiresApproval) {
+          requiresApproval = true;
+        }
+      }
+
+      // 3b. If requires approval, don't execute yet
+      if (requiresApproval) {
+        toolCallResults.push({
+          toolName: tc.name,
+          input: parsedInput,
+          output: null,
+          durationMs: 0,
+          status: "blocked",
+          error: "Requires approval",
+        });
+        continue;
+      }
+
+      // 3c. Execute tool
+      try {
+        const result = await this.toolHandler.execute(tc.name, parsedInput);
+        toolCallResults.push({
+          toolName: tc.name,
+          input: parsedInput,
+          output: result.output,
+          durationMs: result.durationMs,
+          status: "succeeded",
+        });
+        toolMessages.push({
+          role: "tool",
+          content: JSON.stringify(result.output),
+          toolCallId: tc.id,
+        });
+        events.push(emitEvent(input.runId, stepId, "tool.completed", {
+          toolName: tc.name,
+          durationMs: result.durationMs,
+        }));
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        toolCallResults.push({
+          toolName: tc.name,
+          input: parsedInput,
+          output: null,
+          durationMs: 0,
+          status: "failed",
+          error,
+        });
+        toolMessages.push({
+          role: "tool",
+          content: JSON.stringify({ error }),
+          toolCallId: tc.id,
+        });
+        events.push(emitEvent(input.runId, stepId, "step.failed", { toolName: tc.name, error }));
+      }
+    }
+
+    return {
+      messages: [...updatedMessages, ...toolMessages],
+      finishReason: requiresApproval ? "stop" : llmOutput.finishReason,
+      usage: llmOutput.usage,
+      toolCallResults,
+      events,
+      blocked,
+      requiresApproval,
+    };
+  }
+}
+
+/** Reset the internal event counter (for testing). */
+export function _resetStepEventSeq(): void {
+  eventSeq = 0;
+}


### PR DESCRIPTION
## Summary

- `StepExecutor`: 1 Step の実行ライフサイクルをオーケストレーション
  1. LLM 呼び出し → 2. tool calls の policy check → 3. tool 実行 → 4. observation 追加
- 依存注入: `LlmProvider`, `ToolHandler`, `PolicyChecker` インターフェース
- 各フェーズで `ExecutionEvent` を発行（トレーサビリティ）
- エラーハンドリング: provider error, tool failure, policy block
- approval フロー: `requiresApproval` で実行を一時停止

## Test plan

- [x] テキスト応答（tool calls なし）
- [x] tool call 実行 + 結果追加
- [x] tool 実行エラーハンドリング
- [x] LLM provider エラー
- [x] policy deny → blocked
- [x] policy requiresApproval
- [x] policy checker なし
- [x] 7 tests all passing

Closes #4