### PR TITLE
feat(trace): add RunRepository and StepRepository

### DIFF
--- a/packages/trace/src/index.ts
+++ b/packages/trace/src/index.ts
@@ -1,3 +1,5 @@
 export { runs, steps, events, toolCalls, policyDecisions } from "./schema.js";
 export { createDatabase, runMigrations } from "./db.js";
 export type { Database } from "./db.js";
+export { RunRepository, StepRepository } from "./repositories/index.js";
+export type { RunInsert, RunSelect, StepInsert, StepSelect } from "./repositories/index.js";

--- a/packages/trace/src/repositories/index.ts
+++ b/packages/trace/src/repositories/index.ts
@@ -1,0 +1,4 @@
+export { RunRepository } from "./run-repository.js";
+export type { RunInsert, RunSelect } from "./run-repository.js";
+export { StepRepository } from "./step-repository.js";
+export type { StepInsert, StepSelect } from "./step-repository.js";

--- a/packages/trace/src/repositories/run-repository.ts
+++ b/packages/trace/src/repositories/run-repository.ts
@@ -1,0 +1,56 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../db.js";
+import { runs } from "../schema.js";
+
+export type RunInsert = typeof runs.$inferInsert;
+export type RunSelect = typeof runs.$inferSelect;
+
+export class RunRepository {
+  constructor(private db: Database) {}
+
+  async create(run: RunInsert): Promise<RunSelect> {
+    const [result] = await this.db.insert(runs).values(run).returning();
+    return result;
+  }
+
+  async findById(id: string): Promise<RunSelect | undefined> {
+    const [result] = await this.db.select().from(runs).where(eq(runs.id, id));
+    return result;
+  }
+
+  async updateStatus(id: string, status: string, finishedAt?: Date): Promise<void> {
+    await this.db
+      .update(runs)
+      .set({ status, finishedAt: finishedAt ?? null })
+      .where(eq(runs.id, id));
+  }
+
+  async updateTokensAndCost(
+    id: string,
+    totalInputTokens: number,
+    totalOutputTokens: number,
+    estimatedCostUsd: number,
+  ): Promise<void> {
+    await this.db
+      .update(runs)
+      .set({ totalInputTokens, totalOutputTokens, estimatedCostUsd })
+      .where(eq(runs.id, id));
+  }
+
+  async listByStatus(status: string, limit = 50): Promise<RunSelect[]> {
+    return this.db
+      .select()
+      .from(runs)
+      .where(eq(runs.status, status))
+      .orderBy(runs.createdAt)
+      .limit(limit);
+  }
+
+  async listRecent(limit = 50): Promise<RunSelect[]> {
+    return this.db
+      .select()
+      .from(runs)
+      .orderBy(runs.createdAt)
+      .limit(limit);
+  }
+}

--- a/packages/trace/src/repositories/step-repository.ts
+++ b/packages/trace/src/repositories/step-repository.ts
@@ -1,0 +1,55 @@
+import { eq, and } from "drizzle-orm";
+import type { Database } from "../db.js";
+import { steps } from "../schema.js";
+
+export type StepInsert = typeof steps.$inferInsert;
+export type StepSelect = typeof steps.$inferSelect;
+
+export class StepRepository {
+  constructor(private db: Database) {}
+
+  async create(step: StepInsert): Promise<StepSelect> {
+    const [result] = await this.db.insert(steps).values(step).returning();
+    return result;
+  }
+
+  async findById(id: string): Promise<StepSelect | undefined> {
+    const [result] = await this.db.select().from(steps).where(eq(steps.id, id));
+    return result;
+  }
+
+  async updateStatus(id: string, status: string, finishedAt?: Date): Promise<void> {
+    await this.db
+      .update(steps)
+      .set({ status, finishedAt: finishedAt ?? null })
+      .where(eq(steps.id, id));
+  }
+
+  async updateUsage(
+    id: string,
+    inputTokens: number,
+    outputTokens: number,
+    costUsd: number,
+  ): Promise<void> {
+    await this.db
+      .update(steps)
+      .set({ inputTokens, outputTokens, costUsd })
+      .where(eq(steps.id, id));
+  }
+
+  async listByRunId(runId: string): Promise<StepSelect[]> {
+    return this.db
+      .select()
+      .from(steps)
+      .where(eq(steps.runId, runId))
+      .orderBy(steps.stepIndex);
+  }
+
+  async findByRunIdAndIndex(runId: string, stepIndex: number): Promise<StepSelect | undefined> {
+    const [result] = await this.db
+      .select()
+      .from(steps)
+      .where(and(eq(steps.runId, runId), eq(steps.stepIndex, stepIndex)));
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary

- `RunRepository`: CRUD + status/tokens/cost 更新 + status/recent 一覧
- `StepRepository`: CRUD + status/usage 更新 + runId/index 検索
- Drizzle ORM の型安全な query builder を使用

Closes #11