### PR TITLE
feat(examples): add research-agent example

### DIFF
--- a/examples/research-agent/package.json
+++ b/examples/research-agent/package.json
@@ -6,12 +6,18 @@
   "description": "Example research agent",
   "dependencies": {
     "@agentmesh/core": "workspace:*",
-    "@agentmesh/toolkit": "workspace:*"
+    "@agentmesh/policy": "workspace:*",
+    "@agentmesh/provider-openai": "workspace:*",
+    "@agentmesh/toolkit": "workspace:*",
+    "tsx": "^4.21.0"
   },
   "scripts": {
     "start": "tsx src/index.ts",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^25.4.0"
   }
 }

--- a/examples/research-agent/src/index.ts
+++ b/examples/research-agent/src/index.ts
@@ -1,2 +1,136 @@
-// TODO: implement research agent example
-export {};
+import {
+  createRunMachine,
+  transition,
+  incrementStep,
+  checkBudget,
+  StepExecutor,
+} from "@agentmesh/core";
+import type { ToolHandler, PolicyChecker, ProviderMessage } from "@agentmesh/core";
+import { OpenAIProvider } from "@agentmesh/provider-openai";
+import {
+  ToolRegistry,
+  ToolExecutor,
+  webSearchTool,
+  httpFetchTool,
+} from "@agentmesh/toolkit";
+import {
+  PolicyEngine,
+  ToolAllowlistRule,
+  StepBudgetRule,
+  CostBudgetRule,
+} from "@agentmesh/policy";
+
+// --- Config ---
+const GOAL = process.argv[2] ?? "Summarize the latest OSS trends in 2026";
+const MODEL = process.env.MODEL ?? "gpt-4o-mini";
+const MAX_STEPS = 5;
+const MAX_COST = 0.50;
+
+async function main() {
+  console.log(`\n🔬 Research Agent`);
+  console.log(`   Goal: ${GOAL}`);
+  console.log(`   Model: ${MODEL}`);
+  console.log(`   Budget: ${MAX_STEPS} steps, $${MAX_COST}\n`);
+
+  // 1. Setup provider
+  const provider = new OpenAIProvider();
+
+  // 2. Setup tools
+  const registry = new ToolRegistry();
+  registry.register(webSearchTool);
+  registry.register(httpFetchTool);
+
+  const toolExecutor = new ToolExecutor(registry);
+  const toolHandler: ToolHandler = {
+    execute: (name, input) => toolExecutor.execute(name, input),
+    toToolSpecs: () => registry.toJsonSchemas().map((s) => ({
+      name: s.name,
+      description: s.description,
+      parameters: s.parameters,
+    })),
+  };
+
+  // 3. Setup policy
+  const policyEngine = new PolicyEngine();
+  policyEngine.addRule(new ToolAllowlistRule(new Set(["web_search", "http_fetch"])));
+  policyEngine.addRule(new StepBudgetRule(MAX_STEPS));
+  policyEngine.addRule(new CostBudgetRule(MAX_COST));
+
+  const policyChecker: PolicyChecker = {
+    evaluate: (ctx) => policyEngine.evaluate(ctx),
+  };
+
+  // 4. Setup step executor
+  const stepExecutor = new StepExecutor(provider, toolHandler, policyChecker);
+
+  // 5. Run loop
+  let machine = createRunMachine("run_research_1", { maxSteps: MAX_STEPS, maxCostUsd: MAX_COST });
+  const { state: running } = transition(machine, "running");
+  machine = running;
+
+  let messages: ProviderMessage[] = [
+    {
+      role: "system",
+      content: "You are a research assistant. Use web_search and http_fetch tools to find information, then provide a comprehensive summary with sources.",
+    },
+    { role: "user", content: GOAL },
+  ];
+
+  for (let i = 0; i < MAX_STEPS; i++) {
+    const budget = checkBudget(machine);
+    if (budget !== "ok") {
+      console.log(`⚠️  Budget exceeded: ${budget}`);
+      break;
+    }
+
+    console.log(`\n--- Step ${i} ---`);
+    const result = await stepExecutor.execute({
+      runId: machine.runId,
+      stepIndex: i,
+      model: MODEL,
+      messages,
+      currentStepCount: machine.stepCount,
+      totalCostUsd: machine.totalCostUsd,
+    });
+
+    messages = result.messages;
+    machine = incrementStep(machine, result.usage.inputTokens * 0.00001 + result.usage.outputTokens * 0.00003);
+
+    console.log(`   Finish reason: ${result.finishReason}`);
+    console.log(`   Tokens: ${result.usage.inputTokens}in / ${result.usage.outputTokens}out`);
+    console.log(`   Tool calls: ${result.toolCallResults.length}`);
+    for (const tc of result.toolCallResults) {
+      console.log(`     - ${tc.toolName}: ${tc.status} (${tc.durationMs}ms)`);
+    }
+    console.log(`   Events: ${result.events.map((e) => e.eventType).join(", ")}`);
+
+    if (result.finishReason === "stop") {
+      const lastMessage = messages[messages.length - 1];
+      console.log(`\n✅ Research complete!\n`);
+      console.log(lastMessage.content);
+      break;
+    }
+
+    if (result.blocked) {
+      console.log(`🚫 Blocked by policy`);
+      break;
+    }
+
+    if (result.finishReason === "error") {
+      console.log(`❌ Error occurred`);
+      break;
+    }
+  }
+
+  // Final status
+  const finalStatus = machine.status === "running" ? "succeeded" : machine.status;
+  console.log(`\n--- Summary ---`);
+  console.log(`   Status: ${finalStatus}`);
+  console.log(`   Steps: ${machine.stepCount}`);
+  console.log(`   Total cost: $${machine.totalCostUsd.toFixed(4)}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
-    "clean": "turbo run clean"
+    "clean": "turbo run clean",
+    "example:research": "pnpm --filter @agentmesh/example-research-agent start"
   },
   "devDependencies": {
     "turbo": "^2.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,9 +79,22 @@ importers:
       '@agentmesh/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@agentmesh/policy':
+        specifier: workspace:*
+        version: link:../../packages/policy
+      '@agentmesh/provider-openai':
+        specifier: workspace:*
+        version: link:../../packages/provider-openai
       '@agentmesh/toolkit':
         specifier: workspace:*
         version: link:../../packages/toolkit
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+    devDependencies:
+      '@types/node':
+        specifier: ^25.4.0
+        version: 25.4.0
 
   packages/core:
     dependencies:


### PR DESCRIPTION
## Summary

- research-agent: Web検索→記事取得→要約の完全なエージェントループ例
- 全パッケージ統合: core, toolkit, policy, provider-openai
- `pnpm example:research` で実行可能

Closes #15