### PR TITLE
fix: guard JSON.parse in step-executor

### DIFF
--- a/packages/core/src/__tests__/step-executor.test.ts
+++ b/packages/core/src/__tests__/step-executor.test.ts
@@ -110,6 +110,27 @@ describe("StepExecutor", () => {
     expect(result.messages.at(2)?.content).toContain("timeout");
   });
 
+  it("handles invalid JSON tool arguments", async () => {
+    const provider = makeProvider({
+      message: {
+        role: "assistant",
+        content: null,
+        toolCalls: [{ id: "tc_1", name: "search", arguments: "not valid json{" }],
+      },
+      finishReason: "tool_calls",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+    const executor = new StepExecutor(provider, makeToolHandler());
+
+    const result = await executor.execute(makeInput());
+
+    const tc0 = result.toolCallResults.at(0);
+    expect(tc0?.status).toBe("failed");
+    expect(tc0?.error).toContain("Invalid tool arguments JSON");
+    expect(result.messages.at(2)?.role).toBe("tool");
+    expect(result.events.some((e) => e.eventType === "step.failed")).toBe(true);
+  });
+
   it("handles LLM provider error", async () => {
     const provider: LlmProvider = {
       name: "mock",

--- a/packages/core/src/step-executor.ts
+++ b/packages/core/src/step-executor.ts
@@ -134,7 +134,26 @@ export class StepExecutor {
     const toolMessages: ProviderMessage[] = [];
 
     for (const tc of llmOutput.message.toolCalls) {
-      const parsedInput = JSON.parse(tc.arguments) as Record<string, unknown>;
+      let parsedInput: Record<string, unknown>;
+      try {
+        parsedInput = JSON.parse(tc.arguments) as Record<string, unknown>;
+      } catch {
+        toolCallResults.push({
+          toolName: tc.name,
+          input: {},
+          output: null,
+          durationMs: 0,
+          status: "failed",
+          error: `Invalid tool arguments JSON: ${tc.arguments}`,
+        });
+        toolMessages.push({
+          role: "tool",
+          content: JSON.stringify({ error: "Invalid tool arguments JSON" }),
+          toolCallId: tc.id,
+        });
+        events.push(emitEvent(input.runId, stepId, "step.failed", { toolName: tc.name, error: "Invalid JSON arguments" }));
+        continue;
+      }
 
       events.push(emitEvent(input.runId, stepId, "tool.requested", { toolName: tc.name, input: parsedInput }));
 


### PR DESCRIPTION
## Summary
- Wrap `JSON.parse(tc.arguments)` in try/catch for graceful error handling
- Add test for invalid JSON tool arguments
- Invalid JSON now results in a "failed" tool call result instead of crash

Closes #42