### PR TITLE
feat: implement all 5 tool stubs

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -18,6 +18,7 @@
     "clean": "rm -rf dist"
   },
   "devDependencies": {
+    "@types/node": "^25.4.0",
     "vitest": "^4.0.18"
   }
 }

--- a/packages/toolkit/src/tools/http-fetch.ts
+++ b/packages/toolkit/src/tools/http-fetch.ts
@@ -17,7 +17,13 @@ export const httpFetchTool = defineTool({
   sideEffectLevel: "external_read",
   timeoutMs: 10_000,
   retryPolicy: { maxAttempts: 2, backoffMs: 500 },
-  async execute(_input) {
-    throw new Error("http_fetch: not implemented — provide a concrete adapter");
+  async execute(input) {
+    const res = await fetch(input.url, { method: input.method });
+    const body = await res.text();
+    const headers: Record<string, string> = {};
+    res.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+    return { status: res.status, body, headers };
   },
 });

--- a/packages/toolkit/src/tools/read-file.ts
+++ b/packages/toolkit/src/tools/read-file.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { readFile } from "node:fs/promises";
 import { defineTool } from "../define-tool.js";
 
 export const readFileTool = defineTool({
@@ -15,7 +16,8 @@ export const readFileTool = defineTool({
   permissionScope: "file:read",
   sideEffectLevel: "read_only",
   timeoutMs: 5_000,
-  async execute(_input) {
-    throw new Error("read_file: not implemented — provide a concrete adapter");
+  async execute(input) {
+    const content = await readFile(input.path, { encoding: input.encoding as BufferEncoding });
+    return { content, size: Buffer.byteLength(content) };
   },
 });

--- a/packages/toolkit/src/tools/run-shell.ts
+++ b/packages/toolkit/src/tools/run-shell.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { exec } from "node:child_process";
 import { defineTool } from "../define-tool.js";
 
 export const runShellTool = defineTool({
@@ -17,7 +18,23 @@ export const runShellTool = defineTool({
   permissionScope: "shell:exec",
   sideEffectLevel: "system_mutation",
   timeoutMs: 60_000,
-  async execute(_input) {
-    throw new Error("run_shell: not implemented — provide a concrete adapter");
+  async execute(input) {
+    return new Promise((resolve) => {
+      exec(
+        input.command,
+        {
+          cwd: input.cwd,
+          timeout: input.timeoutMs,
+          maxBuffer: 1024 * 1024,
+        },
+        (error: (Error & { code?: number }) | null, stdout: string, stderr: string) => {
+          resolve({
+            exitCode: error?.code ?? 0,
+            stdout,
+            stderr,
+          });
+        },
+      );
+    });
   },
 });

--- a/packages/toolkit/src/tools/web-search.ts
+++ b/packages/toolkit/src/tools/web-search.ts
@@ -3,7 +3,7 @@ import { defineTool } from "../define-tool.js";
 
 export const webSearchTool = defineTool({
   name: "web_search",
-  description: "Search the web for information",
+  description: "Search the web for information. Requires TAVILY_API_KEY environment variable.",
   inputSchema: z.object({
     query: z.string().describe("Search query"),
     maxResults: z.number().int().positive().default(5).describe("Max results to return"),
@@ -21,7 +21,36 @@ export const webSearchTool = defineTool({
   sideEffectLevel: "external_read",
   timeoutMs: 15_000,
   retryPolicy: { maxAttempts: 2, backoffMs: 1000 },
-  async execute(_input) {
-    throw new Error("web_search: not implemented — provide a concrete adapter");
+  async execute(input) {
+    const apiKey = process.env.TAVILY_API_KEY;
+    if (!apiKey) {
+      throw new Error("TAVILY_API_KEY environment variable is required for web_search");
+    }
+
+    const res = await fetch("https://api.tavily.com/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_key: apiKey,
+        query: input.query,
+        max_results: input.maxResults,
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Tavily API error: ${res.status} ${res.statusText}`);
+    }
+
+    const data = (await res.json()) as {
+      results: Array<{ title: string; url: string; content: string }>;
+    };
+
+    return {
+      results: data.results.map((r) => ({
+        title: r.title,
+        url: r.url,
+        snippet: r.content,
+      })),
+    };
   },
 });

--- a/packages/toolkit/src/tools/write-file.ts
+++ b/packages/toolkit/src/tools/write-file.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { writeFile } from "node:fs/promises";
 import { defineTool } from "../define-tool.js";
 
 export const writeFileTool = defineTool({
@@ -15,7 +16,9 @@ export const writeFileTool = defineTool({
   permissionScope: "file:write",
   sideEffectLevel: "external_write",
   timeoutMs: 5_000,
-  async execute(_input) {
-    throw new Error("write_file: not implemented — provide a concrete adapter");
+  async execute(input) {
+    const bytesWritten = Buffer.byteLength(input.content, input.encoding as BufferEncoding);
+    await writeFile(input.path, input.content, { encoding: input.encoding as BufferEncoding });
+    return { bytesWritten };
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@types/node':
+        specifier: ^25.4.0
+        version: 25.4.0
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.4.0)(tsx@4.21.0)


### PR DESCRIPTION
## Summary
- Replace all `throw new Error("not implemented")` stubs with working implementations
- `http_fetch`: Uses Node.js native fetch
- `web_search`: Tavily API integration
- `read_file` / `write_file`: Node.js fs/promises
- `run_shell`: Node.js child_process

Closes #44