### PR TITLE
test: expand provider adapter tests with edge cases

### DIFF
--- a/packages/provider-anthropic/src/__tests__/mapper.test.ts
+++ b/packages/provider-anthropic/src/__tests__/mapper.test.ts
@@ -83,6 +83,62 @@ describe("toAnthropicMessages", () => {
   });
 });
 
+describe("extractSystemMessage edge cases", () => {
+  it("handles empty messages array", () => {
+    const result = extractSystemMessage([]);
+    expect(result.system).toBeUndefined();
+    expect(result.messages).toHaveLength(0);
+  });
+});
+
+describe("toAnthropicMessages edge cases", () => {
+  it("handles empty messages array", () => {
+    const result = toAnthropicMessages([]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("handles assistant with null content and tool calls", () => {
+    const messages: ProviderMessage[] = [
+      {
+        role: "assistant",
+        content: null,
+        toolCalls: [{ id: "tu_1", name: "search", arguments: '{}' }],
+      },
+    ];
+    const result = toAnthropicMessages(messages);
+    const msg = result[0] as { content: unknown[] };
+    // Should only have tool_use block, no text block for null content
+    expect(msg.content).toHaveLength(1);
+    expect((msg.content[0] as { type: string }).type).toBe("tool_use");
+  });
+
+  it("handles assistant with empty toolCalls array", () => {
+    const messages: ProviderMessage[] = [
+      { role: "assistant", content: "Hi", toolCalls: [] },
+    ];
+    const result = toAnthropicMessages(messages);
+    expect(result[0]).toEqual({ role: "assistant", content: "Hi" });
+  });
+});
+
+describe("fromAnthropicResponse edge cases", () => {
+  it("handles empty content array", () => {
+    const response = {
+      id: "msg_4",
+      type: "message" as const,
+      role: "assistant" as const,
+      model: "claude-sonnet-4-20250514",
+      content: [],
+      stop_reason: "end_turn" as const,
+      stop_sequence: null,
+      usage: { input_tokens: 5, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+    } as Anthropic.Message;
+    const result = fromAnthropicResponse(response);
+    expect(result.message.content).toBeNull();
+    expect(result.finishReason).toBe("stop");
+  });
+});
+
 describe("toAnthropicTools", () => {
   it("maps tool specs", () => {
     const tools: ProviderToolSpec[] = [

--- a/packages/provider-openai/src/__tests__/mapper.test.ts
+++ b/packages/provider-openai/src/__tests__/mapper.test.ts
@@ -102,6 +102,65 @@ describe("fromOpenAIChoice", () => {
   });
 });
 
+describe("toOpenAIMessages edge cases", () => {
+  it("handles empty messages array", () => {
+    const result = toOpenAIMessages([]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("handles null content in assistant message", () => {
+    const messages: ProviderMessage[] = [
+      { role: "assistant", content: null },
+    ];
+    const result = toOpenAIMessages(messages);
+    expect(result[0]).toEqual({ role: "assistant", content: "" });
+  });
+
+  it("handles assistant with empty toolCalls array", () => {
+    const messages: ProviderMessage[] = [
+      { role: "assistant", content: "Hi", toolCalls: [] },
+    ];
+    const result = toOpenAIMessages(messages);
+    const msg = result[0] as OpenAI.ChatCompletionAssistantMessageParam;
+    expect(msg.tool_calls).toBeUndefined();
+  });
+});
+
+describe("fromOpenAIChoice edge cases", () => {
+  it("maps length finish_reason", () => {
+    const choice = {
+      index: 0,
+      message: { role: "assistant" as const, content: "Truncated", refusal: null },
+      finish_reason: "length" as const,
+      logprobs: null,
+    };
+    const result = fromOpenAIChoice(choice);
+    expect(result.finishReason).toBe("length");
+  });
+
+  it("maps content_filter finish_reason", () => {
+    const choice = {
+      index: 0,
+      message: { role: "assistant" as const, content: null, refusal: null },
+      finish_reason: "content_filter" as const,
+      logprobs: null,
+    };
+    const result = fromOpenAIChoice(choice);
+    expect(result.finishReason).toBe("content_filter");
+  });
+
+  it("handles message with no tool_calls", () => {
+    const choice = {
+      index: 0,
+      message: { role: "assistant" as const, content: "Hi", refusal: null },
+      finish_reason: "stop" as const,
+      logprobs: null,
+    };
+    const result = fromOpenAIChoice(choice);
+    expect(result.message.toolCalls).toBeUndefined();
+  });
+});
+
 describe("fromOpenAIUsage", () => {
   it("maps usage", () => {
     const usage = { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 };


### PR DESCRIPTION
## Summary
- Add 10 edge case tests across OpenAI and Anthropic mappers
- Cover: empty arrays, null content, empty toolCalls, finish reasons

Closes #40