### PR TITLE
feat: add support-triage and code-review example agents

### DIFF
--- a/examples/code-review-agent/README.md
+++ b/examples/code-review-agent/README.md
@@ -1,0 +1,44 @@
+# Code Review Agent
+
+Reads a git diff, examines changed files for context, and generates structured code review comments.
+
+## Usage
+
+```bash
+# Review last commit
+pnpm example:code-review
+
+# Review specific diff target
+pnpm example:code-review "main..HEAD"
+pnpm example:code-review "HEAD~3"
+```
+
+## How it works
+
+```
+1. run_shell: git diff <target>
+2. read_file: examine specific files (if needed)
+3. LLM generates structured review:
+   ├── Summary
+   ├── Issues (file, severity, description, suggestion)
+   ├── Positive aspects
+   └── Overall: APPROVE | REQUEST_CHANGES | COMMENT
+```
+
+## Tools
+
+- `read_file` — read source files for additional context
+- `run_shell` — execute `git diff` to get changes
+
+## Policy
+
+- **ToolAllowlistRule**: only `read_file` and `run_shell`
+- **StepBudgetRule**: max 5 steps
+- **CostBudgetRule**: max $0.50
+
+## Environment
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENAI_API_KEY` | (required) | OpenAI API key |
+| `MODEL` | `gpt-4o-mini` | Model to use |

--- a/examples/code-review-agent/package.json
+++ b/examples/code-review-agent/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@agentmesh/example-code-review-agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Example code review agent — reads git diff and generates review comments",
+  "dependencies": {
+    "@agentmesh/core": "workspace:*",
+    "@agentmesh/policy": "workspace:*",
+    "@agentmesh/provider-openai": "workspace:*",
+    "@agentmesh/toolkit": "workspace:*",
+    "tsx": "^4.21.0"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^25.4.0"
+  }
+}

--- a/examples/code-review-agent/src/index.ts
+++ b/examples/code-review-agent/src/index.ts
@@ -1,0 +1,163 @@
+import {
+  createRunMachine,
+  transition,
+  incrementStep,
+  checkBudget,
+  StepExecutor,
+} from "@agentmesh/core";
+import type { ToolHandler, PolicyChecker, ProviderMessage } from "@agentmesh/core";
+import { OpenAIProvider } from "@agentmesh/provider-openai";
+import {
+  ToolRegistry,
+  ToolExecutor,
+  readFileTool,
+  runShellTool,
+} from "@agentmesh/toolkit";
+import {
+  PolicyEngine,
+  ToolAllowlistRule,
+  StepBudgetRule,
+  CostBudgetRule,
+} from "@agentmesh/policy";
+
+// --- Config ---
+const DIFF_TARGET = process.argv[2] ?? "HEAD~1";
+const MODEL = process.env.MODEL ?? "gpt-4o-mini";
+const MAX_STEPS = 5;
+const MAX_COST = 0.50;
+
+const SYSTEM_PROMPT = `You are a code review agent. Your workflow:
+
+1. Run \`git diff ${DIFF_TARGET}\` using the run_shell tool to get the changes
+2. If the diff is large, use read_file to examine specific files for more context
+3. Provide a structured review with:
+
+**Format your final response as:**
+
+## Code Review
+
+### Summary
+One paragraph overview of the changes.
+
+### Issues Found
+For each issue:
+- **File**: path/to/file.ts:lineNumber
+- **Severity**: error | warning | suggestion
+- **Description**: What's wrong and why
+- **Suggestion**: How to fix it
+
+### Positive Aspects
+What was done well.
+
+### Overall Assessment
+APPROVE | REQUEST_CHANGES | COMMENT
+
+Focus on:
+- Bugs and logic errors
+- Security vulnerabilities
+- Performance issues
+- Code style and readability
+- Missing error handling
+- Test coverage gaps`;
+
+async function main() {
+  console.log(`\n🔍 Code Review Agent`);
+  console.log(`   Diff target: ${DIFF_TARGET}`);
+  console.log(`   Model: ${MODEL}`);
+  console.log(`   Budget: ${MAX_STEPS} steps, $${MAX_COST}\n`);
+
+  // 1. Setup provider
+  const provider = new OpenAIProvider();
+
+  // 2. Setup tools — read_file + run_shell only
+  const registry = new ToolRegistry();
+  registry.register(readFileTool);
+  registry.register(runShellTool);
+
+  const toolExecutor = new ToolExecutor(registry);
+  const toolHandler: ToolHandler = {
+    execute: (name, input) => toolExecutor.execute(name, input),
+    toToolSpecs: () => registry.toJsonSchemas().map((s) => ({
+      name: s.name,
+      description: s.description,
+      parameters: s.parameters,
+    })),
+  };
+
+  // 3. Setup policy — restrict to safe tools only
+  const policyEngine = new PolicyEngine();
+  policyEngine.addRule(new ToolAllowlistRule(new Set(["read_file", "run_shell"])));
+  policyEngine.addRule(new StepBudgetRule(MAX_STEPS));
+  policyEngine.addRule(new CostBudgetRule(MAX_COST));
+
+  const policyChecker: PolicyChecker = {
+    evaluate: (ctx) => policyEngine.evaluate(ctx),
+  };
+
+  // 4. Setup step executor
+  const stepExecutor = new StepExecutor(provider, toolHandler, policyChecker);
+
+  // 5. Run loop
+  let machine = createRunMachine("run_review_1", { maxSteps: MAX_STEPS, maxCostUsd: MAX_COST });
+  const { state: running } = transition(machine, "running");
+  machine = running;
+
+  let messages: ProviderMessage[] = [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: `Please review the code changes in \`git diff ${DIFF_TARGET}\`. Start by running the diff command.` },
+  ];
+
+  for (let i = 0; i < MAX_STEPS; i++) {
+    const budget = checkBudget(machine);
+    if (budget !== "ok") {
+      console.log(`Budget exceeded: ${budget}`);
+      break;
+    }
+
+    console.log(`\n--- Step ${i} ---`);
+    const result = await stepExecutor.execute({
+      runId: machine.runId,
+      stepIndex: i,
+      model: MODEL,
+      messages,
+      currentStepCount: machine.stepCount,
+      totalCostUsd: machine.totalCostUsd,
+    });
+
+    messages = result.messages;
+    machine = incrementStep(machine, result.usage.inputTokens * 0.00001 + result.usage.outputTokens * 0.00003);
+
+    console.log(`   Finish: ${result.finishReason}`);
+    console.log(`   Tokens: ${result.usage.inputTokens}in / ${result.usage.outputTokens}out`);
+    for (const tc of result.toolCallResults) {
+      console.log(`   Tool: ${tc.toolName} (${tc.status}, ${tc.durationMs}ms)`);
+    }
+
+    if (result.finishReason === "stop") {
+      const lastMessage = messages.at(-1);
+      console.log(`\n${"=".repeat(60)}`);
+      console.log(lastMessage?.content);
+      console.log(`${"=".repeat(60)}`);
+      break;
+    }
+
+    if (result.blocked) {
+      console.log(`Blocked by policy`);
+      break;
+    }
+
+    if (result.finishReason === "error") {
+      console.log(`Error occurred`);
+      break;
+    }
+  }
+
+  console.log(`\n--- Summary ---`);
+  console.log(`   Steps: ${machine.stepCount}`);
+  console.log(`   Cost: $${machine.totalCostUsd.toFixed(4)}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/examples/code-review-agent/tsconfig.json
+++ b/examples/code-review-agent/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/support-triage-agent/README.md
+++ b/examples/support-triage-agent/README.md
@@ -1,0 +1,36 @@
+# Support Triage Agent
+
+Classifies customer support tickets, assigns priority, routes to the right team, and drafts a reply — all using LLM only (no tools).
+
+## Usage
+
+```bash
+# Default sample ticket
+pnpm example:support-triage
+
+# Custom ticket
+pnpm example:support-triage "Subject: billing error\n\nI was charged twice this month."
+```
+
+## How it works
+
+```
+Ticket text → LLM classification → JSON output
+  ├── category: bug | feature | billing | account | other
+  ├── priority: P0 | P1 | P2 | P3
+  ├── team:     engineering | product | finance | support-l2
+  ├── summary:  one-line description
+  └── draft_reply: customer-facing response
+```
+
+## Policy
+
+- **StepBudgetRule**: max 3 steps
+- **CostBudgetRule**: max $0.20
+
+## Environment
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENAI_API_KEY` | (required) | OpenAI API key |
+| `MODEL` | `gpt-4o-mini` | Model to use |

--- a/examples/support-triage-agent/package.json
+++ b/examples/support-triage-agent/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@agentmesh/example-support-triage-agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Example support triage agent — classifies and drafts replies",
+  "dependencies": {
+    "@agentmesh/core": "workspace:*",
+    "@agentmesh/policy": "workspace:*",
+    "@agentmesh/provider-openai": "workspace:*",
+    "tsx": "^4.21.0"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^25.4.0"
+  }
+}

--- a/examples/support-triage-agent/src/index.ts
+++ b/examples/support-triage-agent/src/index.ts
@@ -1,0 +1,142 @@
+import {
+  createRunMachine,
+  transition,
+  incrementStep,
+  checkBudget,
+  StepExecutor,
+} from "@agentmesh/core";
+import type { PolicyChecker, ProviderMessage } from "@agentmesh/core";
+import { OpenAIProvider } from "@agentmesh/provider-openai";
+import {
+  PolicyEngine,
+  StepBudgetRule,
+  CostBudgetRule,
+} from "@agentmesh/policy";
+
+// --- Config ---
+const TICKET = process.argv[2] ?? `Subject: Can't log in after password reset
+From: alice@example.com
+Priority: High
+
+I reset my password yesterday, and now I keep getting "Invalid credentials" when I try to log in.
+I've tried clearing cookies and using a different browser, but nothing works.
+This is blocking my team from accessing our project dashboard.`;
+
+const MODEL = process.env.MODEL ?? "gpt-4o-mini";
+const MAX_STEPS = 3;
+const MAX_COST = 0.20;
+
+const SYSTEM_PROMPT = `You are a customer support triage agent. Your job is to:
+
+1. **Classify** the ticket into one of these categories:
+   - bug: Software defect or malfunction
+   - feature: Feature request or enhancement
+   - billing: Payment, subscription, or pricing issue
+   - account: Account access, permissions, or settings
+   - other: Anything that doesn't fit above
+
+2. **Assess priority**: P0 (critical), P1 (high), P2 (medium), P3 (low)
+
+3. **Route** to the appropriate team:
+   - engineering: For bugs and technical issues
+   - product: For feature requests
+   - finance: For billing issues
+   - support-l2: For account and complex issues
+
+4. **Draft a reply** to the customer that:
+   - Acknowledges their issue
+   - Sets expectations for resolution time
+   - Asks for any additional info if needed
+
+Respond in this exact JSON format:
+{
+  "category": "bug|feature|billing|account|other",
+  "priority": "P0|P1|P2|P3",
+  "team": "engineering|product|finance|support-l2",
+  "summary": "One-line summary of the issue",
+  "draft_reply": "The reply to send to the customer"
+}`;
+
+async function main() {
+  console.log(`\n📋 Support Triage Agent`);
+  console.log(`   Model: ${MODEL}`);
+  console.log(`   Budget: ${MAX_STEPS} steps, $${MAX_COST}\n`);
+  console.log(`--- Ticket ---`);
+  console.log(TICKET);
+  console.log(`--------------\n`);
+
+  // 1. Setup provider
+  const provider = new OpenAIProvider();
+
+  // 2. No tools needed — LLM-only classification
+  const toolHandler = {
+    execute: async () => ({ output: "{}", durationMs: 0 }),
+    toToolSpecs: () => [],
+  };
+
+  // 3. Setup policy
+  const policyEngine = new PolicyEngine();
+  policyEngine.addRule(new StepBudgetRule(MAX_STEPS));
+  policyEngine.addRule(new CostBudgetRule(MAX_COST));
+
+  const policyChecker: PolicyChecker = {
+    evaluate: (ctx) => policyEngine.evaluate(ctx),
+  };
+
+  // 4. Setup step executor
+  const stepExecutor = new StepExecutor(provider, toolHandler, policyChecker);
+
+  // 5. Run
+  let machine = createRunMachine("run_triage_1", { maxSteps: MAX_STEPS, maxCostUsd: MAX_COST });
+  const { state: running } = transition(machine, "running");
+  machine = running;
+
+  const messages: ProviderMessage[] = [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: `Please triage this support ticket:\n\n${TICKET}` },
+  ];
+
+  const budget = checkBudget(machine);
+  if (budget !== "ok") {
+    console.log(`Budget exceeded: ${budget}`);
+    return;
+  }
+
+  console.log(`--- Processing ---`);
+  const result = await stepExecutor.execute({
+    runId: machine.runId,
+    stepIndex: 0,
+    model: MODEL,
+    messages,
+    currentStepCount: machine.stepCount,
+    totalCostUsd: machine.totalCostUsd,
+  });
+
+  machine = incrementStep(machine, result.usage.inputTokens * 0.00001 + result.usage.outputTokens * 0.00003);
+
+  console.log(`   Tokens: ${result.usage.inputTokens}in / ${result.usage.outputTokens}out`);
+  console.log(`   Cost: $${machine.totalCostUsd.toFixed(4)}`);
+
+  const lastMessage = result.messages.at(-1);
+  if (lastMessage?.content) {
+    console.log(`\n--- Triage Result ---`);
+    try {
+      const triage = JSON.parse(lastMessage.content);
+      console.log(`   Category: ${triage.category}`);
+      console.log(`   Priority: ${triage.priority}`);
+      console.log(`   Route to: ${triage.team}`);
+      console.log(`   Summary:  ${triage.summary}`);
+      console.log(`\n--- Draft Reply ---`);
+      console.log(triage.draft_reply);
+    } catch {
+      console.log(lastMessage.content);
+    }
+  }
+
+  console.log(`\n--- Done ---`);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/examples/support-triage-agent/tsconfig.json
+++ b/examples/support-triage-agent/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "clean": "turbo run clean",
-    "example:research": "pnpm --filter @agentmesh/example-research-agent start"
+    "example:research": "pnpm --filter @agentmesh/example-research-agent start",
+    "example:support-triage": "pnpm --filter @agentmesh/example-support-triage-agent start",
+    "example:code-review": "pnpm --filter @agentmesh/example-code-review-agent start"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@types/node':
         specifier: ^25.4.0
         version: 25.4.0
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.4.0)(tsx@4.21.0)
 
   apps/web:
     dependencies:
@@ -89,6 +92,28 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  examples/code-review-agent:
+    dependencies:
+      '@agentmesh/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@agentmesh/policy':
+        specifier: workspace:*
+        version: link:../../packages/policy
+      '@agentmesh/provider-openai':
+        specifier: workspace:*
+        version: link:../../packages/provider-openai
+      '@agentmesh/toolkit':
+        specifier: workspace:*
+        version: link:../../packages/toolkit
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+    devDependencies:
+      '@types/node':
+        specifier: ^25.4.0
+        version: 25.4.0
+
   examples/research-agent:
     dependencies:
       '@agentmesh/core':
@@ -103,6 +128,25 @@ importers:
       '@agentmesh/toolkit':
         specifier: workspace:*
         version: link:../../packages/toolkit
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+    devDependencies:
+      '@types/node':
+        specifier: ^25.4.0
+        version: 25.4.0
+
+  examples/support-triage-agent:
+    dependencies:
+      '@agentmesh/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@agentmesh/policy':
+        specifier: workspace:*
+        version: link:../../packages/policy
+      '@agentmesh/provider-openai':
+        specifier: workspace:*
+        version: link:../../packages/provider-openai
       tsx:
         specifier: ^4.21.0
         version: 4.21.0


### PR DESCRIPTION
## Summary
- **support-triage-agent**: LLMのみでチケット分類・優先度判定・チームルーティング・返信ドラフト生成
- **code-review-agent**: `read_file` + `run_shell` ツールでgit diffを読み、構造化レビューコメントを生成
- ルートの `package.json` に `example:support-triage` / `example:code-review` スクリプト追加

## Test plan
- [x] `pnpm --filter @agentmesh/example-support-triage-agent typecheck` — pass
- [x] `pnpm --filter @agentmesh/example-code-review-agent typecheck` — pass

Closes #51