### PR TITLE
feat: add create-agentmesh TUI setup wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "clean": "turbo run clean",
     "example:research": "pnpm --filter @agentmesh/example-research-agent start",
     "example:support-triage": "pnpm --filter @agentmesh/example-support-triage-agent start",
-    "example:code-review": "pnpm --filter @agentmesh/example-code-review-agent start"
+    "example:code-review": "pnpm --filter @agentmesh/example-code-review-agent start",
+    "create": "pnpm --filter create-agentmesh dev"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.57.0",

--- a/packages/create-agentmesh/package.json
+++ b/packages/create-agentmesh/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "create-agentmesh",
+  "version": "0.1.0",
+  "type": "module",
+  "bin": {
+    "create-agentmesh": "dist/index.js"
+  },
+  "description": "Interactive setup wizard for AgentMesh projects",
+  "files": ["dist"],
+  "dependencies": {
+    "@clack/prompts": "^0.11.0"
+  },
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^25.4.0",
+    "tsx": "^4.21.0"
+  }
+}

--- a/packages/create-agentmesh/src/index.ts
+++ b/packages/create-agentmesh/src/index.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import * as p from "@clack/prompts";
+import { resolve } from "node:path";
+import { existsSync } from "node:fs";
+import type { ProjectConfig } from "./templates.js";
+import { scaffold } from "./scaffold.js";
+
+async function main() {
+  p.intro("AgentMesh Setup");
+
+  const projectName = await p.text({
+    message: "Project name",
+    placeholder: "my-agent",
+    defaultValue: "my-agent",
+    validate: (value) => {
+      if (!value.trim()) return "Project name is required";
+      if (!/^[a-z0-9-]+$/.test(value)) return "Use lowercase letters, numbers, and hyphens only";
+      return undefined;
+    },
+  });
+
+  if (p.isCancel(projectName)) {
+    p.cancel("Setup cancelled.");
+    process.exit(0);
+  }
+
+  const targetDir = resolve(process.cwd(), projectName);
+  if (existsSync(targetDir)) {
+    p.cancel(`Directory "${projectName}" already exists.`);
+    process.exit(1);
+  }
+
+  const provider = await p.select({
+    message: "Provider",
+    options: [
+      { value: "openai" as const, label: "OpenAI", hint: "gpt-4o, gpt-4o-mini" },
+      { value: "anthropic" as const, label: "Anthropic", hint: "claude-sonnet-4-20250514" },
+      { value: "both" as const, label: "Both" },
+    ],
+  });
+
+  if (p.isCancel(provider)) {
+    p.cancel("Setup cancelled.");
+    process.exit(0);
+  }
+
+  const modelOptions =
+    provider === "anthropic"
+      ? [
+          { value: "claude-sonnet-4-20250514", label: "Claude Sonnet 4", hint: "balanced" },
+          { value: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5", hint: "fast & cheap" },
+        ]
+      : [
+          { value: "gpt-4o-mini", label: "gpt-4o-mini", hint: "fast & cheap" },
+          { value: "gpt-4o", label: "gpt-4o", hint: "balanced" },
+        ];
+
+  const model = await p.select({
+    message: "Default model",
+    options: modelOptions,
+  });
+
+  if (p.isCancel(model)) {
+    p.cancel("Setup cancelled.");
+    process.exit(0);
+  }
+
+  const template = await p.select({
+    message: "Template",
+    options: [
+      { value: "research" as const, label: "Research Agent", hint: "web search + summarize" },
+      { value: "support-triage" as const, label: "Support Triage", hint: "ticket classification" },
+      { value: "empty" as const, label: "Empty", hint: "minimal boilerplate" },
+    ],
+  });
+
+  if (p.isCancel(template)) {
+    p.cancel("Setup cancelled.");
+    process.exit(0);
+  }
+
+  const config: ProjectConfig = {
+    projectName,
+    provider,
+    model,
+    template,
+  };
+
+  const s = p.spinner();
+  s.start("Generating project...");
+
+  const files = await scaffold(targetDir, config);
+
+  s.stop("Project generated!");
+
+  p.note(files.map((f) => `  ${f}`).join("\n"), "Created files");
+
+  const providerKeyName =
+    provider === "anthropic" ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY";
+
+  p.outro(`Next steps:
+
+  cd ${projectName}
+  npm install
+  export ${providerKeyName}=sk-your-key
+  npx tsx src/agent.ts`);
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/packages/create-agentmesh/src/scaffold.ts
+++ b/packages/create-agentmesh/src/scaffold.ts
@@ -1,0 +1,32 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { ProjectConfig } from "./templates.js";
+import {
+  generatePackageJson,
+  generateTsconfig,
+  generateEnv,
+  generateGitignore,
+  generateAgentCode,
+} from "./templates.js";
+
+export async function scaffold(dir: string, config: ProjectConfig): Promise<string[]> {
+  const srcDir = join(dir, "src");
+  await mkdir(srcDir, { recursive: true });
+
+  const files: Array<{ path: string; content: string }> = [
+    { path: "package.json", content: generatePackageJson(config) },
+    { path: "tsconfig.json", content: generateTsconfig() },
+    { path: ".env", content: generateEnv(config) },
+    { path: ".gitignore", content: generateGitignore() },
+    { path: "src/agent.ts", content: generateAgentCode(config) },
+  ];
+
+  const written: string[] = [];
+  for (const file of files) {
+    const fullPath = join(dir, file.path);
+    await writeFile(fullPath, file.content, "utf-8");
+    written.push(file.path);
+  }
+
+  return written;
+}

--- a/packages/create-agentmesh/src/templates.ts
+++ b/packages/create-agentmesh/src/templates.ts
@@ -1,0 +1,362 @@
+export interface ProjectConfig {
+  projectName: string;
+  provider: "openai" | "anthropic" | "both";
+  model: string;
+  template: "research" | "support-triage" | "empty";
+}
+
+export function generatePackageJson(config: ProjectConfig): string {
+  const deps: Record<string, string> = {
+    "@agentmesh/core": "^0.1.0",
+    "@agentmesh/policy": "^0.1.0",
+    "@agentmesh/toolkit": "^0.1.0",
+  };
+
+  if (config.provider === "openai" || config.provider === "both") {
+    deps["@agentmesh/provider-openai"] = "^0.1.0";
+  }
+  if (config.provider === "anthropic" || config.provider === "both") {
+    deps["@agentmesh/provider-anthropic"] = "^0.1.0";
+  }
+
+  const pkg = {
+    name: config.projectName,
+    version: "0.1.0",
+    private: true,
+    type: "module",
+    scripts: {
+      dev: "tsx src/agent.ts",
+      build: "tsc",
+      typecheck: "tsc --noEmit",
+    },
+    dependencies: deps,
+    devDependencies: {
+      "@types/node": "^25.4.0",
+      tsx: "^4.21.0",
+      typescript: "^5.8.3",
+    },
+  };
+
+  return JSON.stringify(pkg, null, 2) + "\n";
+}
+
+export function generateTsconfig(): string {
+  const config = {
+    compilerOptions: {
+      target: "ES2022",
+      module: "Node16",
+      moduleResolution: "Node16",
+      strict: true,
+      esModuleInterop: true,
+      skipLibCheck: true,
+      outDir: "dist",
+      rootDir: "src",
+      declaration: true,
+    },
+    include: ["src"],
+    exclude: ["node_modules", "dist"],
+  };
+
+  return JSON.stringify(config, null, 2) + "\n";
+}
+
+export function generateEnv(config: ProjectConfig): string {
+  const lines: string[] = ["# AgentMesh environment variables", ""];
+
+  if (config.provider === "openai" || config.provider === "both") {
+    lines.push("OPENAI_API_KEY=sk-your-key-here");
+  }
+  if (config.provider === "anthropic" || config.provider === "both") {
+    lines.push("ANTHROPIC_API_KEY=sk-ant-your-key-here");
+  }
+
+  lines.push("");
+  lines.push(`MODEL=${config.model}`);
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+export function generateGitignore(): string {
+  return `node_modules/
+dist/
+.env
+*.tsbuildinfo
+`;
+}
+
+export function generateAgentCode(config: ProjectConfig): string {
+  if (config.template === "empty") {
+    return generateEmptyAgent(config);
+  }
+  if (config.template === "support-triage") {
+    return generateSupportTriageAgent(config);
+  }
+  return generateResearchAgent(config);
+}
+
+function getProviderImport(config: ProjectConfig): string {
+  if (config.provider === "anthropic") {
+    return `import { AnthropicProvider } from "@agentmesh/provider-anthropic";`;
+  }
+  return `import { OpenAIProvider } from "@agentmesh/provider-openai";`;
+}
+
+function getProviderInit(config: ProjectConfig): string {
+  if (config.provider === "anthropic") {
+    return `new AnthropicProvider()`;
+  }
+  return `new OpenAIProvider()`;
+}
+
+function generateEmptyAgent(config: ProjectConfig): string {
+  return `import {
+  createRunMachine,
+  transition,
+  incrementStep,
+  checkBudget,
+  StepExecutor,
+} from "@agentmesh/core";
+import type { PolicyChecker, ProviderMessage } from "@agentmesh/core";
+${getProviderImport(config)}
+import { PolicyEngine, StepBudgetRule, CostBudgetRule } from "@agentmesh/policy";
+
+const GOAL = process.argv[2] ?? "Hello, world!";
+const MODEL = process.env.MODEL ?? "${config.model}";
+const MAX_STEPS = 3;
+const MAX_COST = 0.10;
+
+async function main() {
+  console.log("Agent starting...");
+  console.log("Goal:", GOAL);
+
+  const provider = ${getProviderInit(config)};
+
+  const toolHandler = {
+    execute: async () => ({ output: "{}", durationMs: 0 }),
+    toToolSpecs: () => [],
+  };
+
+  const policyEngine = new PolicyEngine();
+  policyEngine.addRule(new StepBudgetRule(MAX_STEPS));
+  policyEngine.addRule(new CostBudgetRule(MAX_COST));
+  const policyChecker: PolicyChecker = { evaluate: (ctx) => policyEngine.evaluate(ctx) };
+
+  const stepExecutor = new StepExecutor(provider, toolHandler, policyChecker);
+
+  let machine = createRunMachine("run_1", { maxSteps: MAX_STEPS, maxCostUsd: MAX_COST });
+  const { state: running } = transition(machine, "running");
+  machine = running;
+
+  const messages: ProviderMessage[] = [
+    { role: "system", content: "You are a helpful assistant." },
+    { role: "user", content: GOAL },
+  ];
+
+  const budget = checkBudget(machine);
+  if (budget !== "ok") {
+    console.log("Budget exceeded:", budget);
+    return;
+  }
+
+  const result = await stepExecutor.execute({
+    runId: machine.runId,
+    stepIndex: 0,
+    model: MODEL,
+    messages,
+    currentStepCount: machine.stepCount,
+    totalCostUsd: machine.totalCostUsd,
+  });
+
+  machine = incrementStep(machine, result.usage.inputTokens * 0.00001 + result.usage.outputTokens * 0.00003);
+
+  const lastMessage = result.messages.at(-1);
+  console.log("\\nResponse:", lastMessage?.content);
+  console.log("Tokens:", result.usage.inputTokens, "in /", result.usage.outputTokens, "out");
+}
+
+main().catch(console.error);
+`;
+}
+
+function generateResearchAgent(config: ProjectConfig): string {
+  return `import {
+  createRunMachine,
+  transition,
+  incrementStep,
+  checkBudget,
+  StepExecutor,
+} from "@agentmesh/core";
+import type { ToolHandler, PolicyChecker, ProviderMessage } from "@agentmesh/core";
+${getProviderImport(config)}
+import { ToolRegistry, ToolExecutor, webSearchTool, httpFetchTool } from "@agentmesh/toolkit";
+import { PolicyEngine, ToolAllowlistRule, StepBudgetRule, CostBudgetRule } from "@agentmesh/policy";
+
+const GOAL = process.argv[2] ?? "Summarize the latest trends in AI agents";
+const MODEL = process.env.MODEL ?? "${config.model}";
+const MAX_STEPS = 5;
+const MAX_COST = 0.50;
+
+async function main() {
+  console.log("Research Agent");
+  console.log("Goal:", GOAL);
+  console.log("Model:", MODEL);
+
+  const provider = ${getProviderInit(config)};
+
+  const registry = new ToolRegistry();
+  registry.register(webSearchTool);
+  registry.register(httpFetchTool);
+
+  const toolExecutor = new ToolExecutor(registry);
+  const toolHandler: ToolHandler = {
+    execute: (name, input) => toolExecutor.execute(name, input),
+    toToolSpecs: () => registry.toJsonSchemas().map((s) => ({
+      name: s.name,
+      description: s.description,
+      parameters: s.parameters,
+    })),
+  };
+
+  const policyEngine = new PolicyEngine();
+  policyEngine.addRule(new ToolAllowlistRule(new Set(["web_search", "http_fetch"])));
+  policyEngine.addRule(new StepBudgetRule(MAX_STEPS));
+  policyEngine.addRule(new CostBudgetRule(MAX_COST));
+  const policyChecker: PolicyChecker = { evaluate: (ctx) => policyEngine.evaluate(ctx) };
+
+  const stepExecutor = new StepExecutor(provider, toolHandler, policyChecker);
+
+  let machine = createRunMachine("run_research_1", { maxSteps: MAX_STEPS, maxCostUsd: MAX_COST });
+  const { state: running } = transition(machine, "running");
+  machine = running;
+
+  let messages: ProviderMessage[] = [
+    { role: "system", content: "You are a research assistant. Use web_search and http_fetch to find information, then provide a summary with sources." },
+    { role: "user", content: GOAL },
+  ];
+
+  for (let i = 0; i < MAX_STEPS; i++) {
+    const budget = checkBudget(machine);
+    if (budget !== "ok") {
+      console.log("Budget exceeded:", budget);
+      break;
+    }
+
+    console.log("\\n--- Step", i, "---");
+    const result = await stepExecutor.execute({
+      runId: machine.runId,
+      stepIndex: i,
+      model: MODEL,
+      messages,
+      currentStepCount: machine.stepCount,
+      totalCostUsd: machine.totalCostUsd,
+    });
+
+    messages = result.messages;
+    machine = incrementStep(machine, result.usage.inputTokens * 0.00001 + result.usage.outputTokens * 0.00003);
+
+    console.log("  Finish:", result.finishReason);
+    for (const tc of result.toolCallResults) {
+      console.log("  Tool:", tc.toolName, tc.status, tc.durationMs + "ms");
+    }
+
+    if (result.finishReason === "stop") {
+      console.log("\\nResult:\\n", messages.at(-1)?.content);
+      break;
+    }
+    if (result.blocked || result.finishReason === "error") break;
+  }
+
+  console.log("\\nSteps:", machine.stepCount, "Cost: $" + machine.totalCostUsd.toFixed(4));
+}
+
+main().catch(console.error);
+`;
+}
+
+function generateSupportTriageAgent(config: ProjectConfig): string {
+  return `import {
+  createRunMachine,
+  transition,
+  incrementStep,
+  checkBudget,
+  StepExecutor,
+} from "@agentmesh/core";
+import type { PolicyChecker, ProviderMessage } from "@agentmesh/core";
+${getProviderImport(config)}
+import { PolicyEngine, StepBudgetRule, CostBudgetRule } from "@agentmesh/policy";
+
+const TICKET = process.argv[2] ?? \`Subject: Can't log in after password reset
+From: alice@example.com
+
+I reset my password yesterday, and now I keep getting "Invalid credentials".
+I've tried clearing cookies and using a different browser, but nothing works.\`;
+
+const MODEL = process.env.MODEL ?? "${config.model}";
+const MAX_STEPS = 3;
+const MAX_COST = 0.20;
+
+const SYSTEM_PROMPT = \`You are a customer support triage agent. Classify the ticket and respond in JSON:
+{
+  "category": "bug|feature|billing|account|other",
+  "priority": "P0|P1|P2|P3",
+  "team": "engineering|product|finance|support-l2",
+  "summary": "One-line summary",
+  "draft_reply": "Reply to customer"
+}\`;
+
+async function main() {
+  console.log("Support Triage Agent");
+
+  const provider = ${getProviderInit(config)};
+
+  const toolHandler = {
+    execute: async () => ({ output: "{}", durationMs: 0 }),
+    toToolSpecs: () => [],
+  };
+
+  const policyEngine = new PolicyEngine();
+  policyEngine.addRule(new StepBudgetRule(MAX_STEPS));
+  policyEngine.addRule(new CostBudgetRule(MAX_COST));
+  const policyChecker: PolicyChecker = { evaluate: (ctx) => policyEngine.evaluate(ctx) };
+
+  const stepExecutor = new StepExecutor(provider, toolHandler, policyChecker);
+
+  let machine = createRunMachine("run_triage_1", { maxSteps: MAX_STEPS, maxCostUsd: MAX_COST });
+  const { state: running } = transition(machine, "running");
+  machine = running;
+
+  const messages: ProviderMessage[] = [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: "Triage this ticket:\\n\\n" + TICKET },
+  ];
+
+  const result = await stepExecutor.execute({
+    runId: machine.runId,
+    stepIndex: 0,
+    model: MODEL,
+    messages,
+    currentStepCount: machine.stepCount,
+    totalCostUsd: machine.totalCostUsd,
+  });
+
+  machine = incrementStep(machine, result.usage.inputTokens * 0.00001 + result.usage.outputTokens * 0.00003);
+
+  const lastMessage = result.messages.at(-1);
+  if (lastMessage?.content) {
+    try {
+      const triage = JSON.parse(lastMessage.content);
+      console.log("Category:", triage.category);
+      console.log("Priority:", triage.priority);
+      console.log("Team:", triage.team);
+      console.log("Summary:", triage.summary);
+      console.log("\\nDraft Reply:\\n", triage.draft_reply);
+    } catch {
+      console.log(lastMessage.content);
+    }
+  }
+}
+
+main().catch(console.error);
+`;
+}

--- a/packages/create-agentmesh/tsconfig.json
+++ b/packages/create-agentmesh/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,19 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.4.0)(tsx@4.21.0)
 
+  packages/create-agentmesh:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^0.11.0
+        version: 0.11.0
+    devDependencies:
+      '@types/node':
+        specifier: ^25.4.0
+        version: 25.4.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+
   packages/policy:
     dependencies:
       '@agentmesh/core':
@@ -253,6 +266,12 @@ packages:
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
+
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -1812,6 +1831,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -2049,6 +2071,17 @@ snapshots:
       zod: 4.3.6
 
   '@babel/runtime@7.28.6': {}
+
+  '@clack/core@0.5.0':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.11.0':
+    dependencies:
+      '@clack/core': 0.5.0
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -3321,6 +3354,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
+
+  sisteransi@1.0.5: {}
 
   sonic-boom@4.2.1:
     dependencies:


### PR DESCRIPTION
## Summary
- `@clack/prompts` でインタラクティブな TUI セットアップウィザードを実装
- Provider選択 → Model選択 → Template選択の3ステップ
- テンプレート3種類: Research Agent / Support Triage / Empty
- `package.json`, `tsconfig.json`, `.env`, `.gitignore`, `src/agent.ts` を自動生成
- `pnpm create` or `npx create-agentmesh` で実行

## Test plan
- [x] `pnpm --filter create-agentmesh typecheck` — pass
- [x] `pnpm --filter create-agentmesh build` — pass
- [x] TUI 起動確認（@clack/prompts のインタラクティブプロンプト表示）

Closes #52