### PR TITLE
feat: add parentRunId/workflowId to Run schema

### DIFF
--- a/packages/core/src/run-machine.ts
+++ b/packages/core/src/run-machine.ts
@@ -31,6 +31,8 @@ export interface RunMachineState {
   stepCount: number;
   totalCostUsd: number;
   budget: RunBudget;
+  parentRunId?: string | undefined;
+  workflowId?: string | undefined;
 }
 
 export interface TransitionResult {
@@ -87,6 +89,7 @@ export function checkBudget(state: RunMachineState): "ok" | "steps_exceeded" | "
 export function createRunMachine(
   runId: string,
   budget: RunBudget = {},
+  options?: { parentRunId?: string; workflowId?: string },
 ): RunMachineState {
   return {
     runId,
@@ -94,6 +97,8 @@ export function createRunMachine(
     stepCount: 0,
     totalCostUsd: 0,
     budget,
+    parentRunId: options?.parentRunId,
+    workflowId: options?.workflowId,
   };
 }
 

--- a/packages/core/src/schema/event.ts
+++ b/packages/core/src/schema/event.ts
@@ -3,6 +3,9 @@ import { z } from "zod";
 export const EventType = z.enum([
   "run.created",
   "run.started",
+  "run.spawned",
+  "run.child_completed",
+  "run.child_failed",
   "step.started",
   "llm.called",
   "llm.responded",

--- a/packages/core/src/schema/run.ts
+++ b/packages/core/src/schema/run.ts
@@ -22,6 +22,8 @@ export const Run = z.object({
   totalTokensInput: z.number().int().nonnegative(),
   totalTokensOutput: z.number().int().nonnegative(),
   estimatedCostUsd: z.number().nonnegative(),
+  parentRunId: z.string().nullable().default(null),
+  workflowId: z.string().nullable().default(null),
   metadata: z.record(z.string(), z.unknown()).default({}),
 });
 export type Run = z.infer<typeof Run>;

--- a/packages/trace/src/schema.ts
+++ b/packages/trace/src/schema.ts
@@ -23,6 +23,8 @@ export const runs = pgTable(
     estimatedCostUsd: real("estimated_cost_usd").notNull().default(0),
     startedAt: timestamp("started_at", { withTimezone: true }),
     finishedAt: timestamp("finished_at", { withTimezone: true }),
+    parentRunId: text("parent_run_id"),
+    workflowId: text("workflow_id"),
     metadataJson: jsonb("metadata_json").default({}),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -30,6 +32,8 @@ export const runs = pgTable(
     index("idx_runs_status").on(table.status),
     index("idx_runs_created_at").on(table.createdAt),
     index("idx_runs_agent_name").on(table.agentName),
+    index("idx_runs_parent_run_id").on(table.parentRunId),
+    index("idx_runs_workflow_id").on(table.workflowId),
   ],
 );
 


### PR DESCRIPTION
## Summary
- Zod Run スキーマに parentRunId, workflowId (nullable) 追加
- Drizzle runs テーブルに parent_run_id, workflow_id 列 + インデックス追加
- RunMachineState に parentRunId, workflowId フィールド追加
- createRunMachine() に options パラメータ追加
- EventType に run.spawned, run.child_completed, run.child_failed 追加

## Test plan
- [x] pnpm typecheck - 18/18 pass
- [x] pnpm test - 12/12 pass

Closes #66