### PR TITLE
feat: add parent/child run queries and API endpoints

### DIFF
--- a/apps/server/src/__tests__/routes.test.ts
+++ b/apps/server/src/__tests__/routes.test.ts
@@ -11,6 +11,8 @@ function createMockRepos() {
       updateTokensAndCost: vi.fn(),
       listByStatus: vi.fn(),
       listRecent: vi.fn(),
+      listByParentId: vi.fn(),
+      listByWorkflowId: vi.fn(),
     },
     stepRepo: {
       create: vi.fn(),
@@ -322,5 +324,65 @@ describe("POST /api/runs/:id/cancel", () => {
     const res = await app.inject({ method: "POST", url: `/api/runs/${fakeRun.id}/cancel` });
 
     expect(res.statusCode).toBe(409);
+  });
+});
+
+describe("GET /api/runs/:id/children", () => {
+  let deps: MockRepos;
+
+  beforeEach(() => {
+    deps = createMockRepos();
+  });
+
+  it("returns child runs", async () => {
+    deps.runRepo.findById.mockResolvedValue(fakeRun);
+    const childRun = { ...fakeRun, id: "run_child1", parentRunId: fakeRun.id };
+    deps.runRepo.listByParentId.mockResolvedValue([childRun]);
+    const app = buildApp(deps);
+
+    const res = await app.inject({ method: "GET", url: `/api/runs/${fakeRun.id}/children` });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toHaveLength(1);
+    expect(deps.runRepo.listByParentId).toHaveBeenCalledWith(fakeRun.id);
+  });
+
+  it("returns empty array when no children", async () => {
+    deps.runRepo.findById.mockResolvedValue(fakeRun);
+    deps.runRepo.listByParentId.mockResolvedValue([]);
+    const app = buildApp(deps);
+
+    const res = await app.inject({ method: "GET", url: `/api/runs/${fakeRun.id}/children` });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toHaveLength(0);
+  });
+
+  it("returns 404 if parent run not found", async () => {
+    deps.runRepo.findById.mockResolvedValue(undefined);
+    const app = buildApp(deps);
+
+    const res = await app.inject({ method: "GET", url: "/api/runs/nonexistent/children" });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("GET /api/runs?workflowId=", () => {
+  let deps: MockRepos;
+
+  beforeEach(() => {
+    deps = createMockRepos();
+  });
+
+  it("filters by workflowId", async () => {
+    deps.runRepo.listByWorkflowId.mockResolvedValue([fakeRun]);
+    const app = buildApp(deps);
+
+    const res = await app.inject({ method: "GET", url: "/api/runs?workflowId=wf_123" });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toHaveLength(1);
+    expect(deps.runRepo.listByWorkflowId).toHaveBeenCalledWith("wf_123", 50);
   });
 });

--- a/apps/server/src/routes/runs.ts
+++ b/apps/server/src/routes/runs.ts
@@ -18,6 +18,7 @@ const CreateRunBody = z.object({
 
 const ListRunsQuery = z.object({
   status: z.string().optional(),
+  workflowId: z.string().optional(),
   limit: z.coerce.number().int().min(1).max(100).default(50),
 });
 
@@ -66,10 +67,15 @@ export function registerRunRoutes(
     if (!parsed.success) {
       return reply.status(400).send({ error: "Invalid query", details: parsed.error.issues });
     }
-    const { status, limit } = parsed.data;
-    const runs = status
-      ? await runRepo.listByStatus(status, limit)
-      : await runRepo.listRecent(limit);
+    const { status, workflowId, limit } = parsed.data;
+    let runs;
+    if (workflowId) {
+      runs = await runRepo.listByWorkflowId(workflowId, limit);
+    } else if (status) {
+      runs = await runRepo.listByStatus(status, limit);
+    } else {
+      runs = await runRepo.listRecent(limit);
+    }
     return reply.send(runs);
   });
 
@@ -97,6 +103,19 @@ export function registerRunRoutes(
 
     const events = await eventRepo.listByRunId(parsed.data.id);
     return reply.send(events);
+  });
+
+  // GET /api/runs/:id/children — Child runs
+  app.get("/api/runs/:id/children", async (req, reply) => {
+    const parsed = IdParams.safeParse(req.params);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: "Invalid params", details: parsed.error.issues });
+    }
+    const run = await runRepo.findById(parsed.data.id);
+    if (!run) return reply.status(404).send({ error: "Run not found" });
+
+    const children = await runRepo.listByParentId(parsed.data.id);
+    return reply.send(children);
   });
 
   // POST /api/runs/:id/approve — Approve run

--- a/packages/trace/src/repositories/run-repository.ts
+++ b/packages/trace/src/repositories/run-repository.ts
@@ -53,4 +53,21 @@ export class RunRepository {
       .orderBy(runs.createdAt)
       .limit(limit);
   }
+
+  async listByParentId(parentRunId: string): Promise<RunSelect[]> {
+    return this.db
+      .select()
+      .from(runs)
+      .where(eq(runs.parentRunId, parentRunId))
+      .orderBy(runs.createdAt);
+  }
+
+  async listByWorkflowId(workflowId: string, limit = 50): Promise<RunSelect[]> {
+    return this.db
+      .select()
+      .from(runs)
+      .where(eq(runs.workflowId, workflowId))
+      .orderBy(runs.createdAt)
+      .limit(limit);
+  }
 }


### PR DESCRIPTION
## Summary
- RunRepository に listByParentId() / listByWorkflowId() メソッド追加
- GET /api/runs/:id/children エンドポイント追加
- GET /api/runs?workflowId=xxx フィルタ追加
- テスト4本追加（計23テスト）

## Test plan
- [x] vitest run — 23 tests passed

Closes #67