### PR TITLE
feat: add OpenTelemetry instrumentation to core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/core/src/run-loop.ts
+++ b/packages/core/src/run-loop.ts
@@ -1,3 +1,5 @@
+import { trace, SpanStatusCode } from "@opentelemetry/api";
+import type { Span } from "@opentelemetry/api";
 import type { LlmProvider, ProviderMessage, ProviderUsage } from "./provider.js";
 import type { ExecutionEvent } from "./schema/event.js";
 import type { ToolHandler, PolicyChecker } from "./step-executor.js";
@@ -9,6 +11,8 @@ import {
   checkBudget,
   incrementStep,
 } from "./run-machine.js";
+
+const tracer = trace.getTracer("@agentmesh/core");
 
 export interface RunLoopConfig {
   runId: string;
@@ -48,6 +52,16 @@ export class RunLoop {
   }
 
   async execute(): Promise<RunLoopResult> {
+    return tracer.startActiveSpan(`run.${this.config.agentName}`, {
+      attributes: {
+        "agentmesh.run_id": this.config.runId,
+        "agentmesh.agent_name": this.config.agentName,
+        "agentmesh.model": this.config.model,
+      },
+    }, (runSpan: Span) => this._executeInSpan(runSpan));
+  }
+
+  private async _executeInSpan(runSpan: Span): Promise<RunLoopResult> {
     const allEvents: ExecutionEvent[] = [];
     const totalUsage: ProviderUsage = { inputTokens: 0, outputTokens: 0 };
 
@@ -154,6 +168,19 @@ export class RunLoop {
     const endResult = transition(machine, terminalStatus);
     machine = endResult.state;
     emitEvent(endResult.event);
+
+    runSpan.setAttributes({
+      "agentmesh.run.status": finalStatus,
+      "agentmesh.run.total_steps": machine.stepCount,
+      "agentmesh.run.total_cost_usd": machine.totalCostUsd,
+      "agentmesh.run.input_tokens": totalUsage.inputTokens,
+      "agentmesh.run.output_tokens": totalUsage.outputTokens,
+    });
+
+    if (finalStatus !== "succeeded") {
+      runSpan.setStatus({ code: SpanStatusCode.ERROR, message: finalStatus });
+    }
+    runSpan.end();
 
     return {
       status: finalStatus,

--- a/packages/core/src/step-executor.ts
+++ b/packages/core/src/step-executor.ts
@@ -1,3 +1,5 @@
+import { trace, SpanStatusCode } from "@opentelemetry/api";
+import type { Span } from "@opentelemetry/api";
 import type {
   LlmProvider,
   ProviderMessage,
@@ -8,6 +10,8 @@ import type {
 } from "./provider.js";
 import type { RunStatus } from "./schema/run.js";
 import type { ExecutionEvent, EventType } from "./schema/event.js";
+
+const tracer = trace.getTracer("@agentmesh/core");
 
 export interface RunSpawner {
   spawn(config: {
@@ -90,185 +94,242 @@ export class StepExecutor {
   ) {}
 
   async execute(input: StepInput): Promise<StepOutput> {
-    const stepId = `step_${input.runId}_${input.stepIndex}`;
-    const events: ExecutionEvent[] = [];
-    const toolCallResults: ToolCallResult[] = [];
-    let blocked = false;
-    let requiresApproval = false;
+    return tracer.startActiveSpan(`step.${input.stepIndex}`, {
+      attributes: {
+        "agentmesh.run_id": input.runId,
+        "agentmesh.step.index": input.stepIndex,
+        "agentmesh.step.model": input.model,
+      },
+    }, (stepSpan: Span): Promise<StepOutput> => {
+      return this._executeStep(input, stepSpan);
+    });
+  }
 
-    events.push(emitEvent(input.runId, stepId, "step.started", { index: input.stepIndex }));
+  private async _executeStep(input: StepInput, stepSpan: Span): Promise<StepOutput> {
+      const stepId = `step_${input.runId}_${input.stepIndex}`;
+      const events: ExecutionEvent[] = [];
+      const toolCallResults: ToolCallResult[] = [];
+      let blocked = false;
+      let requiresApproval = false;
 
-    // 1. Call LLM
-    events.push(emitEvent(input.runId, stepId, "llm.called", { model: input.model }));
+      events.push(emitEvent(input.runId, stepId, "step.started", { index: input.stepIndex }));
 
-    let llmOutput: ProviderGenerateOutput;
-    try {
-      llmOutput = await this.provider.generate({
-        model: input.model,
-        messages: input.messages,
-        tools: this.toolHandler.toToolSpecs(),
-      });
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      events.push(emitEvent(input.runId, stepId, "step.failed", { error }));
-      return {
-        messages: input.messages,
-        finishReason: "error",
-        usage: { inputTokens: 0, outputTokens: 0 },
-        toolCallResults: [],
-        events,
-        blocked: false,
-        requiresApproval: false,
-      };
-    }
+      // 1. Call LLM
+      events.push(emitEvent(input.runId, stepId, "llm.called", { model: input.model }));
 
-    events.push(emitEvent(input.runId, stepId, "llm.responded", {
-      finishReason: llmOutput.finishReason,
-      usage: llmOutput.usage,
-    }));
-
-    const updatedMessages = [...input.messages, llmOutput.message];
-
-    // 2. If no tool calls, return
-    if (llmOutput.finishReason !== "tool_calls" || !llmOutput.message.toolCalls?.length) {
-      return {
-        messages: updatedMessages,
-        finishReason: llmOutput.finishReason,
-        usage: llmOutput.usage,
-        toolCallResults: [],
-        events,
-        blocked: false,
-        requiresApproval: false,
-      };
-    }
-
-    // 3. Process tool calls
-    const toolMessages: ProviderMessage[] = [];
-
-    for (const tc of llmOutput.message.toolCalls) {
-      let parsedInput: Record<string, unknown>;
+      let llmOutput: ProviderGenerateOutput;
       try {
-        parsedInput = JSON.parse(tc.arguments) as Record<string, unknown>;
-      } catch {
-        toolCallResults.push({
-          toolName: tc.name,
-          input: {},
-          output: null,
-          durationMs: 0,
-          status: "failed",
-          error: `Invalid tool arguments JSON: ${tc.arguments}`,
+        llmOutput = await tracer.startActiveSpan("llm.generate", {
+          attributes: { "agentmesh.llm.model": input.model },
+        }, async (llmSpan: Span) => {
+          try {
+            const result = await this.provider.generate({
+              model: input.model,
+              messages: input.messages,
+              tools: this.toolHandler.toToolSpecs(),
+            });
+            llmSpan.setAttributes({
+              "agentmesh.llm.input_tokens": result.usage.inputTokens,
+              "agentmesh.llm.output_tokens": result.usage.outputTokens,
+              "agentmesh.llm.finish_reason": result.finishReason,
+            });
+            llmSpan.end();
+            return result;
+          } catch (err) {
+            llmSpan.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+            llmSpan.end();
+            throw err;
+          }
         });
-        toolMessages.push({
-          role: "tool",
-          content: JSON.stringify({ error: "Invalid tool arguments JSON" }),
-          toolCallId: tc.id,
-        });
-        events.push(emitEvent(input.runId, stepId, "step.failed", { toolName: tc.name, error: "Invalid JSON arguments" }));
-        continue;
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        events.push(emitEvent(input.runId, stepId, "step.failed", { error }));
+        stepSpan.setStatus({ code: SpanStatusCode.ERROR, message: error });
+        stepSpan.end();
+        return {
+          messages: input.messages,
+          finishReason: "error",
+          usage: { inputTokens: 0, outputTokens: 0 },
+          toolCallResults: [],
+          events,
+          blocked: false,
+          requiresApproval: false,
+        };
       }
 
-      events.push(emitEvent(input.runId, stepId, "tool.requested", { toolName: tc.name, input: parsedInput }));
+      events.push(emitEvent(input.runId, stepId, "llm.responded", {
+        finishReason: llmOutput.finishReason,
+        usage: llmOutput.usage,
+      }));
 
-      // 3a. Policy check
-      if (this.policyChecker) {
-        const decision = await this.policyChecker.evaluate({
-          toolName: tc.name,
-          permissionScope: "",
-          sideEffectLevel: "",
-          runId: input.runId,
-          currentStepCount: input.currentStepCount,
-          totalCostUsd: input.totalCostUsd,
-        });
+      stepSpan.setAttributes({
+        "agentmesh.step.finish_reason": llmOutput.finishReason,
+        "agentmesh.step.input_tokens": llmOutput.usage.inputTokens,
+        "agentmesh.step.output_tokens": llmOutput.usage.outputTokens,
+      });
 
-        events.push(emitEvent(input.runId, stepId, "policy.checked", {
-          toolName: tc.name,
-          allowed: decision.allowed,
-          requiresApproval: decision.requiresApproval,
-        }));
+      const updatedMessages = [...input.messages, llmOutput.message];
 
-        if (!decision.allowed) {
-          blocked = true;
+      // 2. If no tool calls, return
+      if (llmOutput.finishReason !== "tool_calls" || !llmOutput.message.toolCalls?.length) {
+        stepSpan.end();
+        return {
+          messages: updatedMessages,
+          finishReason: llmOutput.finishReason,
+          usage: llmOutput.usage,
+          toolCallResults: [],
+          events,
+          blocked: false,
+          requiresApproval: false,
+        };
+      }
+
+      // 3. Process tool calls
+      const toolMessages: ProviderMessage[] = [];
+
+      for (const tc of llmOutput.message.toolCalls) {
+        let parsedInput: Record<string, unknown>;
+        try {
+          parsedInput = JSON.parse(tc.arguments) as Record<string, unknown>;
+        } catch {
+          toolCallResults.push({
+            toolName: tc.name,
+            input: {},
+            output: null,
+            durationMs: 0,
+            status: "failed",
+            error: `Invalid tool arguments JSON: ${tc.arguments}`,
+          });
+          toolMessages.push({
+            role: "tool",
+            content: JSON.stringify({ error: "Invalid tool arguments JSON" }),
+            toolCallId: tc.id,
+          });
+          events.push(emitEvent(input.runId, stepId, "step.failed", { toolName: tc.name, error: "Invalid JSON arguments" }));
+          continue;
+        }
+
+        events.push(emitEvent(input.runId, stepId, "tool.requested", { toolName: tc.name, input: parsedInput }));
+
+        // 3a. Policy check
+        if (this.policyChecker) {
+          const decision = await this.policyChecker.evaluate({
+            toolName: tc.name,
+            permissionScope: "",
+            sideEffectLevel: "",
+            runId: input.runId,
+            currentStepCount: input.currentStepCount,
+            totalCostUsd: input.totalCostUsd,
+          });
+
+          stepSpan.addEvent("policy.checked", {
+            "agentmesh.tool.name": tc.name,
+            "agentmesh.policy.allowed": decision.allowed,
+            "agentmesh.policy.requires_approval": decision.requiresApproval,
+          });
+
+          events.push(emitEvent(input.runId, stepId, "policy.checked", {
+            toolName: tc.name,
+            allowed: decision.allowed,
+            requiresApproval: decision.requiresApproval,
+          }));
+
+          if (!decision.allowed) {
+            blocked = true;
+            toolCallResults.push({
+              toolName: tc.name,
+              input: parsedInput,
+              output: null,
+              durationMs: 0,
+              status: "blocked",
+              error: decision.reason,
+            });
+            toolMessages.push({
+              role: "tool",
+              content: JSON.stringify({ error: `Policy blocked: ${decision.reason}` }),
+              toolCallId: tc.id,
+            });
+            continue;
+          }
+
+          if (decision.requiresApproval) {
+            requiresApproval = true;
+          }
+        }
+
+        // 3b. If requires approval, don't execute yet
+        if (requiresApproval) {
           toolCallResults.push({
             toolName: tc.name,
             input: parsedInput,
             output: null,
             durationMs: 0,
             status: "blocked",
-            error: decision.reason,
-          });
-          toolMessages.push({
-            role: "tool",
-            content: JSON.stringify({ error: `Policy blocked: ${decision.reason}` }),
-            toolCallId: tc.id,
+            error: "Requires approval",
           });
           continue;
         }
 
-        if (decision.requiresApproval) {
-          requiresApproval = true;
-        }
+        // 3c. Execute tool
+        await tracer.startActiveSpan(`tool.${tc.name}`, {
+          attributes: { "agentmesh.tool.name": tc.name },
+        }, async (toolSpan: Span) => {
+          try {
+            const result = await this.toolHandler.execute(tc.name, parsedInput);
+            toolCallResults.push({
+              toolName: tc.name,
+              input: parsedInput,
+              output: result.output,
+              durationMs: result.durationMs,
+              status: "succeeded",
+            });
+            toolMessages.push({
+              role: "tool",
+              content: JSON.stringify(result.output),
+              toolCallId: tc.id,
+            });
+            toolSpan.setAttribute("agentmesh.tool.duration_ms", result.durationMs);
+            events.push(emitEvent(input.runId, stepId, "tool.completed", {
+              toolName: tc.name,
+              durationMs: result.durationMs,
+            }));
+          } catch (err) {
+            const error = err instanceof Error ? err.message : String(err);
+            toolCallResults.push({
+              toolName: tc.name,
+              input: parsedInput,
+              output: null,
+              durationMs: 0,
+              status: "failed",
+              error,
+            });
+            toolMessages.push({
+              role: "tool",
+              content: JSON.stringify({ error }),
+              toolCallId: tc.id,
+            });
+            toolSpan.setStatus({ code: SpanStatusCode.ERROR, message: error });
+            events.push(emitEvent(input.runId, stepId, "step.failed", { toolName: tc.name, error }));
+          }
+          toolSpan.end();
+        });
       }
 
-      // 3b. If requires approval, don't execute yet
-      if (requiresApproval) {
-        toolCallResults.push({
-          toolName: tc.name,
-          input: parsedInput,
-          output: null,
-          durationMs: 0,
-          status: "blocked",
-          error: "Requires approval",
-        });
-        continue;
-      }
+      stepSpan.setAttributes({
+        "agentmesh.step.blocked": blocked,
+        "agentmesh.step.tool_calls": toolCallResults.length,
+      });
+      stepSpan.end();
 
-      // 3c. Execute tool
-      try {
-        const result = await this.toolHandler.execute(tc.name, parsedInput);
-        toolCallResults.push({
-          toolName: tc.name,
-          input: parsedInput,
-          output: result.output,
-          durationMs: result.durationMs,
-          status: "succeeded",
-        });
-        toolMessages.push({
-          role: "tool",
-          content: JSON.stringify(result.output),
-          toolCallId: tc.id,
-        });
-        events.push(emitEvent(input.runId, stepId, "tool.completed", {
-          toolName: tc.name,
-          durationMs: result.durationMs,
-        }));
-      } catch (err) {
-        const error = err instanceof Error ? err.message : String(err);
-        toolCallResults.push({
-          toolName: tc.name,
-          input: parsedInput,
-          output: null,
-          durationMs: 0,
-          status: "failed",
-          error,
-        });
-        toolMessages.push({
-          role: "tool",
-          content: JSON.stringify({ error }),
-          toolCallId: tc.id,
-        });
-        events.push(emitEvent(input.runId, stepId, "step.failed", { toolName: tc.name, error }));
-      }
-    }
-
-    return {
-      messages: [...updatedMessages, ...toolMessages],
-      finishReason: requiresApproval ? "stop" : llmOutput.finishReason,
-      usage: llmOutput.usage,
-      toolCallResults,
-      events,
-      blocked,
-      requiresApproval,
-    };
+      return {
+        messages: [...updatedMessages, ...toolMessages],
+        finishReason: requiresApproval ? "stop" as const : llmOutput.finishReason,
+        usage: llmOutput.usage,
+        toolCallResults,
+        events,
+        blocked,
+        requiresApproval,
+      };
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         version: 25.4.0
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.4.0)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(tsx@4.21.0)
 
   apps/web:
     dependencies:
@@ -71,7 +71,7 @@ importers:
         version: link:../../packages/ui-contracts
       next:
         specifier: ^16.1.6
-        version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -157,13 +157,16 @@ importers:
 
   packages/core:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.4.0)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(tsx@4.21.0)
 
   packages/create-agentmesh:
     dependencies:
@@ -186,7 +189,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.4.0)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(tsx@4.21.0)
 
   packages/provider-anthropic:
     dependencies:
@@ -199,7 +202,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.4.0)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(tsx@4.21.0)
 
   packages/provider-openai:
     dependencies:
@@ -212,7 +215,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.4.0)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(tsx@4.21.0)
 
   packages/toolkit:
     dependencies:
@@ -228,7 +231,7 @@ importers:
         version: 25.4.0
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.4.0)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(tsx@4.21.0)
 
   packages/trace:
     dependencies:
@@ -237,7 +240,7 @@ importers:
         version: link:../core
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(postgres@3.4.8)
+        version: 0.45.1(@opentelemetry/api@1.9.0)(postgres@3.4.8)
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
@@ -260,7 +263,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.4.0)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(tsx@4.21.0)
 
   tests/e2e:
     devDependencies:
@@ -272,7 +275,7 @@ importers:
         version: link:../../packages/policy
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.4.0)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(tsx@4.21.0)
 
 packages:
 
@@ -1007,6 +1010,10 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -2533,6 +2540,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.6':
     optional: true
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@pinojs/redact@0.4.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
@@ -2852,8 +2861,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1(postgres@3.4.8):
+  drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(postgres@3.4.8):
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       postgres: 3.4.8
 
   es-module-lexer@1.7.0: {}
@@ -3170,7 +3180,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -3189,6 +3199,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
+      '@opentelemetry/api': 1.9.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -3498,7 +3509,7 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@4.0.18(@types/node@25.4.0)(tsx@4.21.0):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.4.0)(tsx@4.21.0))
@@ -3521,6 +3532,7 @@ snapshots:
       vite: 7.3.1(@types/node@25.4.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 25.4.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
## Summary
- @opentelemetry/api を @agentmesh/core に追加し、RunLoop・StepExecutor にスパン計装を実装
- RunLoop: run 単位のルートスパン（ステータス、ステップ数、コスト、トークン数を attributes に記録）
- StepExecutor: step / llm.generate / tool.{name} の子スパンを生成、ポリシーチェックは span events として記録
- TracerProvider 未登録時は完全 no-op（パフォーマンス影響ゼロ）

## Test plan
- [x] 既存 99 テスト全パス（OTel API は no-op モードで動作）
- [x] pnpm --filter @agentmesh/core build 成功
- [ ] TracerProvider 登録時にスパンが正しく生成されることを確認（将来の integration test）

Closes #50